### PR TITLE
Making client consistent with REST API 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="0.1.14",
+    version="0.1.15",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/src/marqo/client.py
+++ b/src/marqo/client.py
@@ -40,27 +40,31 @@ class Client:
         sentences_per_chunk=2,
         sentence_overlap=0,
         image_preprocessing_method=None,
+        settings_dict=None
     ) -> Dict[str, Any]:
-        """
+        """Create the index.
 
         Args:
-            index_name:
+            index_name: name of the index.
             treat_urls_and_pointers_as_images:
             model:
             normalize_embeddings:
             sentences_per_chunk:
             sentence_overlap:
             image_preprocessing_method:
-
+            settings_dict: if specified, overwrites all other setting
+                parameters, and is passed directly as the index's
+                index_settings
         Returns:
-
+            Response body, containing information about index creation result
         """
         return Index.create(
             config=self.config, index_name=index_name,
             treat_urls_and_pointers_as_images=treat_urls_and_pointers_as_images,
             model=model, normalize_embeddings=normalize_embeddings,
             sentences_per_chunk=sentences_per_chunk, sentence_overlap=sentence_overlap,
-            image_preprocessing_method=image_preprocessing_method
+            image_preprocessing_method=image_preprocessing_method,
+            settings_dict=settings_dict
         )
 
     def delete_index(self, index_name: str) -> Dict[str, Any]:

--- a/tests/v0_tests/test_image_chunking.py
+++ b/tests/v0_tests/test_image_chunking.py
@@ -36,7 +36,7 @@ class TestImageChunking(MarqoTestCase):
 
         settings = {
             "treat_urls_and_pointers_as_images":True,   # allows us to find an image file and index it 
-            "model":"ViT-L/14", 
+            "model":"ViT-B/16",
              "image_preprocessing_method" : None
             }
         
@@ -76,7 +76,7 @@ class TestImageChunking(MarqoTestCase):
 
         settings = {
             "treat_urls_and_pointers_as_images":True,   # allows us to find an image file and index it 
-            "model":"ViT-L/14", 
+            "model":"ViT-B/16",
             "image_preprocessing_method":"simple"
             }
         

--- a/tests/v0_tests/test_index.py
+++ b/tests/v0_tests/test_index.py
@@ -1,0 +1,49 @@
+import pprint
+from marqo.client import Client
+from marqo.errors import MarqoApiError, MarqoError, MarqoWebError
+import unittest
+from tests.marqo_test import MarqoTestCase
+from unittest import mock
+
+
+class TestIndex(MarqoTestCase):
+
+    def setUp(self) -> None:
+        self.client = Client(**self.client_settings)
+        self.index_name_1 = "my-test-index-1"
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    def tearDown(self) -> None:
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    def test_create_index_settings_dict(self):
+        """if settings_dict exists, it should override existing params"""
+        for non_settings_dicts_param, settings_dict, expected_treat_urls_and_pointers_as_images in [
+                    ({"treat_urls_and_pointers_as_images": False},
+                     {"index_defaults": {"treat_urls_and_pointers_as_images": True}},
+                     True),
+                    ({"treat_urls_and_pointers_as_images": False},
+                     None,
+                     False),
+                    ({"treat_urls_and_pointers_as_images": False},
+                     {},
+                     False),
+                ]:
+            mock__post = mock.MagicMock()
+            @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+            def run():
+                self.client.create_index(
+                    index_name=self.index_name_1,
+                    settings_dict=settings_dict,
+                    **non_settings_dicts_param)
+                return True
+            assert run()
+            args, kwargs = mock__post.call_args
+            assert dict(kwargs['body'])["index_defaults"]["treat_urls_and_pointers_as_images"] \
+                   is expected_treat_urls_and_pointers_as_images

--- a/tests/v0_tests/test_neural_search.py
+++ b/tests/v0_tests/test_neural_search.py
@@ -57,6 +57,24 @@ class TestAddDocuments(MarqoTestCase):
             "title about some doc")
         assert len(search_res["hits"]) == 0
 
+    def test_search_highlights(self):
+        """Tests if show_highlights works and if the deprecation behaviour is expected"""
+        self.client.create_index(index_name=self.index_name_1)
+        self.client.index(index_name=self.index_name_1).add_documents([{"f1": "some doc"}])
+        for params, expected_highlights_presence in [
+                ({"highlights": True, "show_highlights": False}, False),
+                ({"highlights": False, "show_highlights": True}, False),
+                ({"highlights": True, "show_highlights": True}, True),
+                ({"highlights": True}, True),
+                ({"highlights": False}, False),
+                ({}, True),
+                ({"show_highlights": False}, False),
+                ({"show_highlights": True}, True)
+            ]:
+            search_res = self.client.index(self.index_name_1).search(
+                "title about some doc", **params)
+            assert ("_highlights" in search_res["hits"][0]) is expected_highlights_presence
+
     def test_search_multi(self):
         self.client.create_index(index_name=self.index_name_1)
         d1 = {


### PR DESCRIPTION
- added settings_dict to create index
- made highlights search param consistent with API

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Feature

* **What is the current behavior?** (You can also link to an open issue here)
- Large model is loaded for the image_chunking test. Can make some servers run out memory
- No way to pass a dict of settings straight to the Marqo instance
- Inconsistency in naming the showHighlights parameter for the search endpoint
 
* **What is the new behavior (if this is a feature change)?**
- Smaller model is loaded for the image_chunking test
- You can pass a dict of settings at index creation time with the `settings_dict` parameter
- Consistency for search() showHighlights parameter naming. The old parameter name remains, but logs a deprecated warning. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

