### PR TITLE
Changed all the apperances of reranker to reRanker.

### DIFF
--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -98,7 +98,7 @@ class Index:
     def search(self, q: str, searchable_attributes: Optional[List[str]] = None,
                limit: int = 10, search_method: Union[SearchMethods.TENSOR, str] = SearchMethods.TENSOR,
                highlights=None, device: Optional[str] = None, filter_string: str = None,
-               show_highlights=True, reranker=None,
+               show_highlights=True, reRanker=None,
                attributes_to_retrieve: Optional[List[str]] = None
                ) -> Dict[str, Any]:
         """Search the index.
@@ -110,7 +110,7 @@ class Index:
             limit: The max number of documents to be returned
             search_method: Indicates TENSOR or LEXICAL (keyword) search
             show_highlights: True if highlights are to be returned
-            reranker:
+            reRanker:
             device: the device used to index the data. Examples include "cpu",
                 "cuda" and "cuda:2". Overrides the Client's default device.
             filter_string: a filter string, used to prefilter documents during the
@@ -138,7 +138,7 @@ class Index:
             "limit": limit,
             "searchMethod": search_method,
             "showHighlights": show_highlights,
-            "reranker": reranker,
+            "reRanker": reRanker,
         }
         if attributes_to_retrieve is not None:
             body["attributesToRetrieve"] = attributes_to_retrieve

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -98,7 +98,7 @@ class Index:
     def search(self, q: str, searchable_attributes: Optional[List[str]] = None,
                limit: int = 10, search_method: Union[SearchMethods.TENSOR, str] = SearchMethods.TENSOR,
                highlights=None, device: Optional[str] = None, filter_string: str = None,
-               show_highlights=True, reRanker=None,
+               show_highlights=True, reranker=None,
                attributes_to_retrieve: Optional[List[str]] = None
                ) -> Dict[str, Any]:
         """Search the index.
@@ -138,7 +138,7 @@ class Index:
             "limit": limit,
             "searchMethod": search_method,
             "showHighlights": show_highlights,
-            "reRanker": reRanker,
+            "reRanker": reranker,
         }
         if attributes_to_retrieve is not None:
             body["attributesToRetrieve"] = attributes_to_retrieve


### PR DESCRIPTION
closes https://github.com/marqo-ai/py-marqo/issues/25

- have renamed reranker to reRanker.