### PR TITLE
Batch size patch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="0.5.0",
+    version="0.5.1",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -279,7 +279,7 @@ class Index:
             return self._batch_request(
                 base_path=base_path, auto_refresh=auto_refresh,
                 update_method=update_method, docs=documents, verbose=False,
-                query_str_params=query_str_params
+                query_str_params=query_str_params, batch_size=client_batch_size
             )
         else:
             refresh_option = f"?refresh={str(auto_refresh).lower()}"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: client_batch_size in add_documents and update_documents was previously not propagated to the batching function

* **What is the current behavior?** (You can also link to an open issue here)
client_batch_size was not propagating to the batching function


* **What is the new behavior (if this is a feature change)?**
client_batch_size now propagates to the batching function

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Ran tox.
Created tests for batching in add_documents and update_documents 
