### PR TITLE
Corrected backend communication errors to be about connecting to Marqo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="0.5.4",
+    version="0.5.5",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/src/marqo/errors.py
+++ b/src/marqo/errors.py
@@ -154,7 +154,7 @@ class BackendCommunicationError(InternalError):
     status_code = HTTPStatus.INTERNAL_SERVER_ERROR
 
     def __init__(self, message: str,) -> None:
-        self.message = f"Error communicating with OpenSearch backend: {message}"
+        self.message = f"Error communicating with Marqo: {message}"
 
 
 class BackendTimeoutError(InternalError):
@@ -163,5 +163,5 @@ class BackendTimeoutError(InternalError):
     status_code = HTTPStatus.INTERNAL_SERVER_ERROR
 
     def __init__(self, message: str,) -> None:
-        self.message = f"Timeout error communicating with OpenSearch backend: {message}"
+        self.message = f"Timeout error communicating with Marqo: {message}"
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Backend communication error erroneously attributes all communication errors to be with OpenSearcch

* **What is the new behavior (if this is a feature change)?**
Backend communication errors correctly attribute communication errors to Marqo by default


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Maybe. If you have logic that reads for "OpenSearch backend" in the backend communication error message, it will no longer work.

* **Other information**:
Ran tox
