### PR TITLE
Cloud defaults

### DIFF
--- a/src/marqo/defaults.py
+++ b/src/marqo/defaults.py
@@ -1,0 +1,22 @@
+
+def get_cloud_default_index_settings():
+    """
+    Diverges from default in:
+        - number_of_shards
+    """
+    return {
+        "index_defaults": {
+            "treat_urls_and_pointers_as_images": False,
+            "model": "hf/all_datasets_v4_MiniLM-L6",
+            "normalize_embeddings": True,
+            "text_preprocessing": {
+                "split_length": 2,
+                "split_overlap": 0,
+                "split_method": "sentence"
+            },
+            "image_preprocessing": {
+                "patch_method": None
+            }
+        },
+        "number_of_shards": 2
+    }

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import logging
+import defaults
 import typing
 from urllib import parse
 from datetime import datetime
@@ -75,6 +76,21 @@ class Index:
         if settings_dict is not None and settings_dict:
             return req.post(f"indexes/{index_name}", body=settings_dict)
 
+        if config.api_key is not None:
+            # making the keyword settings params override the default cloud
+            #  settings
+            cl_settings = defaults.get_cloud_default_index_settings()
+            cl_ix_defaults = cl_settings['index_defaults']
+            cl_ix_defaults['treat_urls_and_pointers_as_images'] = treat_urls_and_pointers_as_images
+            cl_ix_defaults['model'] = model
+            cl_ix_defaults['normalize_embeddings'] = normalize_embeddings
+            cl_text_preprocessing = cl_ix_defaults['text_preprocessing']
+            cl_text_preprocessing['split_overlap'] = sentence_overlap
+            cl_text_preprocessing['split_length'] = sentences_per_chunk
+            cl_img_preprocessing = cl_ix_defaults['text_preprocessing']
+            cl_img_preprocessing['patch_method'] = image_preprocessing_method
+            return req.post(f"indexes/{index_name}", body=cl_settings)
+
         return req.post(f"indexes/{index_name}", body={
             "index_defaults": {
                 "treat_urls_and_pointers_as_images": treat_urls_and_pointers_as_images,
@@ -85,7 +101,7 @@ class Index:
                     "split_length": sentences_per_chunk,
                     "split_method": "sentence"
                 },
-                "image_preprocessing":{
+                "image_preprocessing": {
                     "patch_method": image_preprocessing_method
                 }
             }

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -1,7 +1,7 @@
 import functools
 import json
 import logging
-import defaults
+from marqo import defaults
 import typing
 from urllib import parse
 from datetime import datetime

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,5 +1,5 @@
-__marqo_version__ = "0.0.8"
-__marqo_release_page__ = "https://github.com/marqo-ai/marqo/releases/tag/0.0.8"
+__marqo_version__ = "0.0.10"
+__marqo_release_page__ = "https://github.com/marqo-ai/marqo/releases/tag/0.0.10"
 
 
 def supported_marqo_version() -> str:

--- a/tests/v0_tests/test_index.py
+++ b/tests/v0_tests/test_index.py
@@ -137,3 +137,11 @@ class TestIndex(MarqoTestCase):
         assert 'Blurb' in doc_res['_tensor_facets'][0] or 'Title' in doc_res['_tensor_facets'][0]
         assert "Blurb" in doc_res
         assert "Title" in doc_res
+
+    def create_cloud_index(self):
+        """TODO"""
+
+    def create_cloud_index_override_w_settings_dict(self):
+        """TODO"""
+
+


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature - specific set of defaults for creating indices on the cloud, refactor

* **What is the current behavior?** (You can also link to an open issue here)
Cloud indices are set up with the same defaults as non cloud indices

* **What is the new behavior (if this is a feature change)?**
Cloud indices are set up with cloud-specific settings (specifically, number of shards = 2)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:


__Manual testing__ 
1. Confirmed that an index that with a specified model (multilingual), creates and index with 2 shards.
2. Confirmed that an index with default params (`mq.create_index(index_name=self.index_name_1)`) creates an index with 2 shards:
<img width="1087" alt="image" src="https://user-images.githubusercontent.com/107458762/207225897-f4e4da43-5505-4537-a5bb-71f1df8e9310.png">

