### PR TITLE
[FIX] for default settings dict when api key present

### DIFF
--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -87,7 +87,7 @@ class Index:
             cl_text_preprocessing = cl_ix_defaults['text_preprocessing']
             cl_text_preprocessing['split_overlap'] = sentence_overlap
             cl_text_preprocessing['split_length'] = sentences_per_chunk
-            cl_img_preprocessing = cl_ix_defaults['text_preprocessing']
+            cl_img_preprocessing = cl_ix_defaults['image_preprocessing']
             cl_img_preprocessing['patch_method'] = image_preprocessing_method
             return req.post(f"indexes/{index_name}", body=cl_settings)
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix for default settings dict when providing an api key (for cloud access)

* **What is the current behavior?** (You can also link to an open issue here)
`'patch_method':None` even when a patch_method is provided

```python
settings = {
            "treat_urls_and_pointers_as_images":True,   # allows us to find an image file and index it 
            "model":"ViT-B/16",
            "image_preprocessing_method":"simple"
            }

client.create_index(self.index_name, **settings)
```
Result of settings dict in `Index()` object:
```bash
{'index_defaults': {'image_preprocessing': {'patch_method': None},
                    'model': 'ViT-B/16',
                    'normalize_embeddings': True,
                    'text_preprocessing': {'patch_method': 'simple',
                                           'split_length': 2,
                                           'split_method': 'sentence',
                                           'split_overlap': 0},
                    'treat_urls_and_pointers_as_images': True},
 'number_of_shards': 2}
```
* **What is the new behavior (if this is a feature change)?**
N/A

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N/A

* **Other information**:
Proof of tests:
![image](https://user-images.githubusercontent.com/112362822/207805785-4211c81f-9a1a-4ba5-a513-167e08241b07.png)

