### PR TITLE
Pagination offset parameter implemented

### DIFF
--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -114,7 +114,7 @@ class Index:
         return self.http.post(path=F"indexes/{self.index_name}/refresh")
 
     def search(self, q: str, searchable_attributes: Optional[List[str]] = None,
-               limit: int = 10, search_method: Union[SearchMethods.TENSOR, str] = SearchMethods.TENSOR,
+               limit: int = 10, offset: int = 0, search_method: Union[SearchMethods.TENSOR, str] = SearchMethods.TENSOR,
                highlights=None, device: Optional[str] = None, filter_string: str = None,
                show_highlights=True, reranker=None,
                attributes_to_retrieve: Optional[List[str]] = None
@@ -126,6 +126,7 @@ class Index:
                 treat_urls_and_pointers_as_images set to True
             searchable_attributes:  attributes to search
             limit: The max number of documents to be returned
+            offset: The number of search results to skip (for pagination)
             search_method: Indicates TENSOR or LEXICAL (keyword) search
             show_highlights: True if highlights are to be returned
             reranker:
@@ -156,6 +157,7 @@ class Index:
             "q": q,
             "searchableAttributes": searchable_attributes,
             "limit": limit,
+            "offset": offset,
             "searchMethod": search_method,
             "showHighlights": show_highlights,
             "reRanker": reranker,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Pagination feature

* **What is the current behavior?** (You can also link to an open issue here)
Currently, results cannot be paginated. See issue: https://github.com/marqo-ai/marqo/issues/71

* **What is the new behavior (if this is a feature change)?**
This introduces an `offset` parameter, which allows users to skip results (for pagination). This uses the `from` and `size` parameters of open search.

There are some issues with skipping/duplication of results near the edges of the first few pages (around 3% of results affected overall) in tensor search specifically. This is believed to be an issue with OpenSearch KNN, and is being observed in the issue here: https://github.com/opensearch-project/k-NN/issues/698

For now, the unit tests for pagination do not assume exact precision in results when using pagination.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Have unit tests been run against this PR?** (Has there also been any additional testing?)
Yes.

