### PR TITLE
update_documents no longer passes api use_existing_tensors

### DIFF
--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -308,7 +308,6 @@ class Index:
             update_method="update",
             documents=documents, auto_refresh=auto_refresh, server_batch_size=server_batch_size,
             client_batch_size=client_batch_size, processes=processes, device=device, non_tensor_fields=non_tensor_fields,
-            use_existing_tensors=False
         )
 
     def _generic_add_update_docs(
@@ -321,7 +320,7 @@ class Index:
         processes: int = None,
         device: str = None,
         non_tensor_fields: List = None,
-        use_existing_tensors: bool = False
+        use_existing_tensors: bool = None
     ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         if non_tensor_fields is None:
             non_tensor_fields = []
@@ -337,7 +336,7 @@ class Index:
             f"{f'&device={utils.translate_device_string_for_url(selected_device)}'}"
             f"{f'&processes={processes}' if processes is not None else ''}"
             f"{f'&batch_size={server_batch_size}' if server_batch_size is not None else ''}"
-            f"&use_existing_tensors={str(use_existing_tensors).lower()}"
+            f"{f'&use_existing_tensors={str(use_existing_tensors).lower()}' if use_existing_tensors is not None else ''}"
             f"{f'&{non_tensor_fields_query_param}' if len(non_tensor_fields) > 0 else ''}"
         )
         end_time_client_process = timer()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)
currently, the update_documents endpoints apsses the api the use_existing_tensors flag, where it goes unused.

* **What is the new behavior (if this is a feature change)?**
update_documents no longer passes api use_existing_tensors

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:

