### PR TITLE
Use BaseModel's `Config.extra == forbid` to avoid parameter confusion

### DIFF
--- a/src/marqo/models.py
+++ b/src/marqo/models.py
@@ -1,9 +1,14 @@
 from typing import Dict, List, Optional, Union
 from pydantic import BaseModel
 
-from marqo.enums import SearchMethods
 
-class SearchBody(BaseModel):
+class BaseMarqoModel(BaseModel):
+    class Config:
+        extra: str = "forbid"
+    pass
+
+
+class SearchBody(BaseMarqoModel):
     q: Union[str, Dict[str, float]]
     searchableAttributes: Union[None, List[str]] = None
     searchMethod: Union[None, str] = "TENSOR"
@@ -19,5 +24,5 @@ class SearchBody(BaseModel):
 class BulkSearchBody(SearchBody):
     index: str
 
-class BulkSearchQuery(BaseModel):
+class BulkSearchQuery(BaseMarqoModel):
     queries: List[BulkSearchBody]

--- a/tests/v0_tests/test_bulk_search.py
+++ b/tests/v0_tests/test_bulk_search.py
@@ -3,7 +3,7 @@ import marqo
 from marqo import enums
 from unittest import mock
 from marqo.client import Client
-from marqo.errors import MarqoApiError
+from marqo.errors import InvalidArgError, MarqoApiError
 import requests
 import random
 import math
@@ -69,6 +69,16 @@ class TestBulkSearch(MarqoTestCase):
         search_res = resp['result'][0]
 
         assert len(search_res["hits"]) == 0
+
+    def test_search__extra_parameters_raise_exception(self):
+        self.client.create_index(index_name=self.index_name_1)
+        
+        with self.assertRaises(InvalidArgError):
+            self.client.bulk_search([{
+                "index": self.index_name_1,
+                "q": "title about some doc",
+                "parameter-not-expected": 1,
+            }])
 
     def test_search_highlights(self):
         """Tests if show_highlights works and if the deprecation behaviour is expected"""


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
If a user mistypes a parameter to bulk search expecting it to be used as a separate, valid key word they will get confused when the Marqo behaviour is different to what they expected.

* **What is the current behavior?** (You can also link to an open issue here)
For example, if a user thinks a keyword is `attribute_To_Retrieves` (in actuality, it is `attributesToRetrieve`), then
```
mq.bulk_search([{
  "index": "an-index",
  "q": "Some results",
  "attribute_To_Retrieves": ["_id"],
}])
```
The results will have more than just `_id` fields (as `attributesToRetrieve` is not provided). Now, with the above case, an `InvalidArgError` will be thrown stating the unexpected field.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Only if they are passing in an unexpected field.


* **Other information**:

