### PR TITLE
Warning when indexing errs (#76)

### DIFF
--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -342,8 +342,8 @@ class Index:
         mappings: dict = None
     ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
 
-        error_detected_message = ('Errors detected in add documents call. Examine the returned '
-                                  'add documents result object for more information.')
+        error_detected_message = ('Errors detected in add documents call. '
+                                  'Please examine the returned result object for more information.')
         if non_tensor_fields is None:
             non_tensor_fields = []
 
@@ -499,8 +499,8 @@ class Index:
         path_with_query_str = f"{base_path}?refresh=false{query_str_params}"
 
         mq_logger.debug(f"starting batch ingestion with batch size {batch_size}")
-        error_detected_message = ('Errors detected in add documents call. Examine the returned '
-                                  'add documents result object for more information.')
+        error_detected_message = ('Errors detected in add documents call. '
+                                  'Please examine the returned result object for more information.')
 
         deeper = ((doc, i, batch_size) for i, doc in enumerate(docs))
         def batch_requests(gathered, doc_tuple):

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -339,9 +339,11 @@ class Index:
         non_tensor_fields: List = None,
         use_existing_tensors: bool = False,
         image_download_headers: dict = None,
-        mappings:dict = None
+        mappings: dict = None
     ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
 
+        error_detected_message = ('Errors detected in add documents call. Examine the returned '
+                                  'add documents result object for more information.')
         if non_tensor_fields is None:
             non_tensor_fields = []
 
@@ -401,7 +403,7 @@ class Index:
 
             mq_logger.debug(f"add_documents roundtrip: took {(total_client_request_time):.3f}s to send {num_docs} "
                             f"docs to Marqo (roundtrip, unbatched), for an average of {(total_client_request_time / num_docs):.3f}s per doc.")
-
+            errors_detected = False
             if server_batch_size is not None:
                 # with Server Batching (show processing time for each batch)
                 mq_logger.debug(f"add_documents Marqo index (server-side batch reports): ")
@@ -416,6 +418,8 @@ class Index:
                             mq_logger.debug(f"       marqo server batch {batch}: "
                                             f"processed {server_batch_result_count} docs in {(res[process][batch]['processingTimeMs'] / 1000):.3f}s, "
                                             f"for an average of {(res[process][batch]['processingTimeMs'] / (1000 * server_batch_result_count)):.3f}s per doc.")
+                            if 'errors' in res[process][batch] and res[process][batch]['errors']:
+                                errors_detected = True
                 else:
                     # for single process, timing messages should be arranged by batch ONLY
                     for batch in range(len(res)):
@@ -423,12 +427,18 @@ class Index:
                         mq_logger.debug(f"   marqo server batch {batch}: "
                                         f"processed {server_batch_result_count} docs in {(res[batch]['processingTimeMs'] / 1000):.3f}s, "
                                         f"for an average of {(res[batch]['processingTimeMs'] / (1000 * server_batch_result_count)):.3f}s per doc.")
+                        if 'errors' in res[batch] and res[batch]['errors']:
+                            errors_detected = True
             else:
                 # no Server Batching
                 if 'processingTimeMs' in res:       # Only outputs log if response is non-empty
                     mq_logger.debug(f"add_documents Marqo index: took {(res['processingTimeMs'] / 1000):.3f}s for Marqo to process & index {num_docs} "
                                     f"docs (server unbatched), for an average of {(res['processingTimeMs'] / (1000 * num_docs)):.3f}s per doc.")
+                if 'errors' in res and res['errors']:
+                    mq_logger.info(error_detected_message)
 
+            if errors_detected:
+                mq_logger.info(error_detected_message)
         total_add_docs_time = timer() - t0
         mq_logger.debug(f"add_documents completed. total time taken: {(total_add_docs_time):.3f}s.")
         return res
@@ -489,9 +499,10 @@ class Index:
         path_with_query_str = f"{base_path}?refresh=false{query_str_params}"
 
         mq_logger.debug(f"starting batch ingestion with batch size {batch_size}")
+        error_detected_message = ('Errors detected in add documents call. Examine the returned '
+                                  'add documents result object for more information.')
 
         deeper = ((doc, i, batch_size) for i, doc in enumerate(docs))
-
         def batch_requests(gathered, doc_tuple):
             doc, i, the_batch_size = doc_tuple
             if i % the_batch_size == 0:
@@ -503,6 +514,8 @@ class Index:
         batched = functools.reduce(lambda x, y: batch_requests(x, y), deeper, [])
 
         def verbosely_add_docs(i, docs):
+            errors_detected = False
+
             t0 = timer()
             if update_method == 'replace':
                 res = self.http.post(path=path_with_query_str, body=docs)
@@ -517,7 +530,7 @@ class Index:
             if isinstance(res, list):
                 # with Server Batching (show processing time for each batch)
                 mq_logger.info(
-                    f"   add_documents batch {i} roundtrip: took {(total_batch_time):.3f}s to add {num_docs} docs, "
+                    f"    add_documents batch {i} roundtrip: took {(total_batch_time):.3f}s to add {num_docs} docs, "
                     f"for an average of {(total_batch_time / num_docs):.3f}s per doc.")
 
                 if isinstance(res[0], list):
@@ -530,6 +543,9 @@ class Index:
                             mq_logger.debug(f"           marqo server batch {batch}: "
                                             f"processed {server_batch_result_count} docs in {(res[process][batch]['processingTimeMs'] / 1000):.3f}s, "
                                             f"for an average of {(res[process][batch]['processingTimeMs'] / (1000 * server_batch_result_count)):.3f}s per doc.")
+                            if 'errors' in res[process][batch] and res[process][batch]['errors']:
+                                errors_detected = True
+
                 else:
                     # for single process, timing messages should be arranged by batch ONLY
                     for batch in range(len(res)):
@@ -537,15 +553,20 @@ class Index:
                         mq_logger.debug(f"       marqo server batch {batch}: "
                                         f"processed {server_batch_result_count} docs in {(res[batch]['processingTimeMs'] / 1000):.3f}s, "
                                         f"for an average of {(res[batch]['processingTimeMs'] / (1000 * server_batch_result_count)):.3f}s per doc.")
+                        if 'errors' in res[batch] and res[batch]['errors']:
+                            errors_detected = True
             else:
                 # no Server Batching
                 if 'processingTimeMs' in res:       # Only outputs log if response is non-empty
                     mq_logger.info(
-                        f"   add_documents batch {i}: took {(res['processingTimeMs'] / 1000):.3f}s for Marqo to process & index {num_docs} "
+                        f"    add_documents batch {i}: took {(res['processingTimeMs'] / 1000):.3f}s for Marqo to process & index {num_docs} "
                         f"docs (server unbatched), for an average of {(res['processingTimeMs'] / (1000 * num_docs)):.3f}s per doc."
                         f" Roundtrip time: {(total_batch_time):.3f}s")
+                    if 'errors' in res and res['errors']:
+                        errors_detected = True
 
-
+            if errors_detected:
+                mq_logger.info(f"    add_documents batch {i}: {error_detected_message}")
             if verbose:
                 mq_logger.info(f"results from indexing batch {i}: {res}")
             return res

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -17,7 +17,6 @@ class MarqoTestCase(unittest.TestCase):
         local_marqo_settings = {
             "url": os.environ.get("MARQO_URL", 'http://localhost:8882'),
         }
-
         api_key = os.environ.get("MARQO_API_KEY", None)
         if (api_key):
             local_marqo_settings["api_key"] = api_key

--- a/tests/v0_tests/test_index.py
+++ b/tests/v0_tests/test_index.py
@@ -193,7 +193,7 @@ class TestIndex(MarqoTestCase):
         assert run()
 
     def test_create_custom_number_of_replicas(self):
-        intended_replicas = 5
+        intended_replicas = 0
         settings = {
             "number_of_replicas": intended_replicas
         }

--- a/tests/v0_tests/test_logging.py
+++ b/tests/v0_tests/test_logging.py
@@ -1,0 +1,97 @@
+import copy
+import pprint
+
+import marqo
+from marqo.client import Client
+from marqo.errors import MarqoApiError, MarqoError, MarqoWebError
+import unittest
+from tests.marqo_test import MarqoTestCase
+from unittest import mock
+import requests
+marqo.set_log_level("INFO")
+
+class TestLogging(MarqoTestCase):
+
+    def setUp(self) -> None:
+        self.client = Client(**self.client_settings)
+        self.index_name_1 = "my-test-index-1"
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    def tearDown(self) -> None:
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    @staticmethod
+    def _get_docs_to_index():
+        return [
+            # 5 OK docs:
+            {"_id": "123", "Title": "Moon person"},
+            {"_id": "124", "Title": "Shark island"},
+            {"_id": "125", "Title": "3 people in a bar"},
+            {"_id": "125", "Title": "4 people in a bar"},
+            {"_id": "101", "Title": "blach"},
+
+            {"_id": "102", "Title": "blach"},
+            {"_id": "126", "Title": "https://marqo.ai/this_image_doesnt_exist.png"},  # bad
+            {"_id": "103", "Title": "ooditty the second"},
+            {"_id": "104", "Title": "wolol the second"},
+            {"_id": "105", "Title": "strange the second"},
+
+            {"_id": "127", "Title": "https://marqo.ai/this_image_doesnt_exist.png"},  # bad as well
+            {"_id": "106", "Title": "blach"},
+            {"_id": "108", "Title": "blach the third"},
+            {"_id": "131", "Title": "blach the forf"},
+            {"_id": "189", "Title": "https://marqo.ai/this_image_doesnt_too_exist.png"},  # bad as well
+
+            {"_id": "109", "Title": "Sun person"},
+            {"_id": "110", "Title": "Shark Shar"},
+            {"_id": "111", "Title": "3 people in a car"},
+            {"_id": "112", "Title": "4 people in a limo"},
+            {"_id": "113", "Title": "Wow"},
+        ]
+
+    def _create_img_index(self, index_name):
+        self.client.create_index(index_name=index_name, treat_urls_and_pointers_as_images=True, model='ViT-B/32')
+
+    def test_add_document_warnings_no_batching(self):
+        self._create_img_index(index_name=self.index_name_1)
+        with self.assertLogs('marqo', level='INFO') as cm:
+            self.client.index(index_name=self.index_name_1).add_documents(self._get_docs_to_index())
+            assert len(cm.output) == 1
+            assert "errors detected" in cm.output[0].lower()
+            assert "info" in cm.output[0].lower()
+
+    def test_add_document_warnings_client_batching(self):
+        self._create_img_index(index_name=self.index_name_1)
+        params_expected = [
+            # so no client batching, that means no batch info output,  and therefore only 1 warning
+            ({}, {"num_log_msgs": 1, "num_errors_msgs": 1}),
+            ({'server_batch_size': 5}, {"num_log_msgs": 1, "num_errors_msgs": 1}),
+            ({'server_batch_size': 5, "processes": 2}, {"num_log_msgs": 1, "num_errors_msgs": 1}),
+            ({"processes": 2}, {"num_log_msgs": 1, "num_errors_msgs": 1}),
+
+            # one error message, one regular info message per client batch
+            ({"client_batch_size": 5}, {"num_log_msgs": 6, "num_errors_msgs": 2}),
+            ({"client_batch_size": 10, 'server_batch_size': 5}, {"num_log_msgs": 4, "num_errors_msgs": 2}),
+            ({"client_batch_size": 10, 'server_batch_size': 5, "processes": 2},
+             {"num_log_msgs": 4, "num_errors_msgs": 2}),
+            ({"client_batch_size": 10, "processes": 2}, {"num_log_msgs": 4, "num_errors_msgs": 2}),
+
+        ]
+        for params, expected in params_expected:
+
+            with self.assertLogs('marqo', level='INFO') as cm:
+                self.client.index(index_name=self.index_name_1).add_documents(
+                    documents=self._get_docs_to_index(), **params)
+                print(params, expected)
+                assert len(cm.output) == expected['num_log_msgs']
+                error_messages = [msg.lower() for msg in cm.output if "errors detected" in msg.lower()]
+                assert len(error_messages) == expected['num_errors_msgs']
+                assert all(["info" in msg for msg in error_messages])
+                assert len(["info" in msg for msg in error_messages]) == expected['num_errors_msgs']
+


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
No warning when users add documents, and there are errors adding those documents. This can lead to a large batch ingestion without users ever realising there were errors

* **What is the new behavior (if this is a feature change)?**
INFO level logs messages (once per add_documents call or once per client batch) that indicate that some document had an error being indexed 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:

