### PR TITLE
add api support for score_modifiers

### DIFF
--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -118,7 +118,7 @@ class Index:
                highlights=None, device: Optional[str] = None, filter_string: str = None,
                show_highlights=True, reranker=None, image_download_headers: Optional[Dict] = None,
                attributes_to_retrieve: Optional[List[str]] = None, boost: Optional[Dict[str,List[Union[float, int]]]] = None,
-               context: Optional[dict] = None,
+               context: Optional[dict] = None, score_modifiers: Optional[dict] = None,
                ) -> Dict[str, Any]:
         """Search the index.
 
@@ -144,6 +144,7 @@ class Index:
                 retrieved. If left as None, then all attributes will be
                 retrieved.
             context: a dictionary to allow you to bring your own vectors and more into search.
+            score_modifiers: a dictionary to modify the score based on field values, for tensor search only
         Returns:
             Dictionary with hits and other metadata
         """
@@ -177,6 +178,8 @@ class Index:
             body["image_download_headers"] = image_download_headers
         if context is not None:
             body["context"] = context
+        if score_modifiers is not None:
+            body["scoreModifiers"] = score_modifiers
         res = self.http.post(
             path=path_with_query_str,
             body=body

--- a/src/marqo/models.py
+++ b/src/marqo/models.py
@@ -20,9 +20,17 @@ class SearchBody(BaseMarqoModel):
     attributesToRetrieve: Union[None, List[str]] = None
     boost: Optional[Dict] = None
     image_download_headers: Optional[Dict] = None
+    context: Optional[Dict] = None
+    scoreModifiers: Optional[Dict] = None
+
 
 class BulkSearchBody(SearchBody):
     index: str
+    # Attributes that are not supported in bulk search
+    context: None = None
+    scoreModifiers: None = None
+
+
 
 class BulkSearchQuery(BaseMarqoModel):
     queries: List[BulkSearchBody]

--- a/src/marqo/models.py
+++ b/src/marqo/models.py
@@ -31,6 +31,5 @@ class BulkSearchBody(SearchBody):
     scoreModifiers: None = None
 
 
-
 class BulkSearchQuery(BaseMarqoModel):
     queries: List[BulkSearchBody]

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -104,7 +104,7 @@ class TestCustomVectorSearch(MarqoTestCase):
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
             "q": "title about some doc",
-            "void" : {
+            "void-void" : {
                 # typo in multiply score by
                 "multiply_score_bys":
                     [{"field_name": "multiply_1",

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -82,7 +82,8 @@ class TestCustomVectorSearch(MarqoTestCase):
             }
 
         try:
-            modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=invalid_score_modifiers)
+            modifiers_res = self.client.index(self.index_name_1).search(q=self.query,
+                                                                        score_modifiers = invalid_score_modifiers)
             raise AssertionError
         except MarqoWebError:
             pass

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -121,7 +121,3 @@ class TestScoreModifierSearch(MarqoTestCase):
             raise AssertionError
         except MarqoWebError:
             pass
-
-
-
-

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -104,7 +104,7 @@ class TestCustomVectorSearch(MarqoTestCase):
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
             "q": "title about some doc",
-            "scoreModifiers" : {
+            "scoreModifidfdfdfders" : {
                 # typo in multiply score by
                 "multiply_score_bys":
                     [{"field_name": "multiply_1",

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -75,7 +75,7 @@ class TestCustomVectorSearch(MarqoTestCase):
                       "weight": 1,},
                      {"field_name": "multiply_2",}],
                 "add_to_score": [
-                    {"field_name": "add_1", "weight" : -3,
+                    {"field_name": "add_1", "weight" : 4,
                      },
                     {"field_name": "add_2", "weight": 1,
                      }]
@@ -86,6 +86,18 @@ class TestCustomVectorSearch(MarqoTestCase):
             raise AssertionError
         except MarqoWebError:
             pass
+
+    def test_valid_score_modifiers_format(self):
+        invalid_score_modifiers = {
+                # missing one part
+                "add_to_score": [
+                    {"field_name": "add_1", "weight" : -3,
+                     },
+                    {"field_name": "add_2", "weight": 1,
+                     }]
+            }
+
+        modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=invalid_score_modifiers)
 
 
 

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -65,7 +65,7 @@ class TestCustomVectorSearch(MarqoTestCase):
         modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=score_modifiers)
 
         modifiers_score = modifiers_res["hits"][0]["_score"]
-
-        self.assertEqual(original_score * 20 * 1 + 1 * -3 + 30 * 1, modifiers_score)
+        expected_sore = original_score * 20 * 1 + 1 * -3 + 30 * 1
+        assert abs(expected_sore -modifiers_score)
 
 

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -101,22 +101,27 @@ class TestCustomVectorSearch(MarqoTestCase):
         modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=valid_score_modifiers)
 
     def test_bulk_search_error(self):
-        resp = self.client.bulk_search([{
-            "index": self.index_name_1,
-            "q": "title about some doc",
-            "scoreModifiers" : {
-                # typo in multiply score by
-                "multiply_score_bys":
-                    [{"field_name": "multiply_1",
-                      "weight": 1,},
-                     {"field_name": "multiply_2",}],
-                "add_to_score": [
-                    {"field_name": "add_1", "weight" : 4,
-                     },
-                    {"field_name": "add_2", "weight": 1,
-                     }]
-            }
-        }])
+        try:
+            resp = self.client.bulk_search([{
+                "index": self.index_name_1,
+                "q": "title about some doc",
+                "scoreModifiers" : {
+                    # typo in multiply score by
+                    "multiply_score_bys":
+                        [{"field_name": "multiply_1",
+                          "weight": 1,},
+                         {"field_name": "multiply_2",}],
+                    "add_to_score": [
+                        {"field_name": "add_1", "weight" : 4,
+                         },
+                        {"field_name": "add_2", "weight": 1,
+                         }]
+                }
+            }])
+
+            raise AssertionError
+        except MarqoWebError:
+            pass
 
 
 

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -66,6 +66,6 @@ class TestCustomVectorSearch(MarqoTestCase):
 
         modifiers_score = modifiers_res["hits"][0]["_score"]
         expected_sore = original_score * 20 * 1 + 1 * -3 + 30 * 1
-        assert abs(expected_sore -modifiers_score)
+        assert abs(expected_sore -modifiers_score) < 1e-5
 
 

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -104,7 +104,7 @@ class TestCustomVectorSearch(MarqoTestCase):
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
             "q": "title about some doc",
-            "scoreModifidfdfdfders" : {
+            "void" : {
                 # typo in multiply score by
                 "multiply_score_bys":
                     [{"field_name": "multiply_1",

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -54,7 +54,7 @@ class TestCustomVectorSearch(MarqoTestCase):
                      },
                     {"field_name": "add_2", "weight": 1,
                      }]
-            },
+            }
 
         original_res = self.client.index(self.index_name_1).search(q = self.query, score_modifiers=None,
                                                                      filter_string="filter:original")

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -100,5 +100,23 @@ class TestCustomVectorSearch(MarqoTestCase):
 
         modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=valid_score_modifiers)
 
+    def test_bulk_search_error(self):
+        resp = self.client.bulk_search([{
+            "index": self.index_name_1,
+            "q": "title about some doc",
+            "scoreModifiers" : {
+                # typo in multiply score by
+                "multiply_score_bys":
+                    [{"field_name": "multiply_1",
+                      "weight": 1,},
+                     {"field_name": "multiply_2",}],
+                "add_to_score": [
+                    {"field_name": "add_1", "weight" : 4,
+                     },
+                    {"field_name": "add_2", "weight": 1,
+                     }]
+            }
+        }])
+
 
 

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -101,26 +101,23 @@ class TestCustomVectorSearch(MarqoTestCase):
         modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=valid_score_modifiers)
 
     def test_bulk_search_error(self):
-        try:
-            resp = self.client.bulk_search([{
-                "index": self.index_name_1,
-                "q": "title about some doc",
-                "scoreModifiers" : {
-                    # typo in multiply score by
-                    "multiply_score_bys":
-                        [{"field_name": "multiply_1",
-                          "weight": 1,},
-                         {"field_name": "multiply_2",}],
-                    "add_to_score": [
-                        {"field_name": "add_1", "weight" : 4,
-                         },
-                        {"field_name": "add_2", "weight": 1,
-                         }]
-                }
-            }])
-            raise AssertionError
-        except MarqoWebError:
-            pass
+        resp = self.client.bulk_search([{
+            "index": self.index_name_1,
+            "q": "title about some doc",
+            "scoreModifiers" : {
+                # typo in multiply score by
+                "multiply_score_bys":
+                    [{"field_name": "multiply_1",
+                      "weight": 1,},
+                     {"field_name": "multiply_2",}],
+                "add_to_score": [
+                    {"field_name": "add_1", "weight" : 4,
+                     },
+                    {"field_name": "add_2", "weight": 1,
+                     }]
+            }
+        }])
+
 
 
 

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -1,0 +1,71 @@
+from marqo.client import Client
+from marqo.errors import MarqoApiError, MarqoError, MarqoWebError
+from tests.marqo_test import MarqoTestCase
+
+
+class TestCustomVectorSearch(MarqoTestCase):
+
+    def setUp(self) -> None:
+        self.client = Client(**self.client_settings)
+        self.index_name_1 = "my-test-index-1"
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+        self.client.create_index(index_name=self.index_name_1, model="ViT-B/32")
+        self.client.index(index_name=self.index_name_1).add_documents(
+            documents=[
+                {"my_text_field": "A rider is riding a horse jumping over the barrier.",
+                 "my_image_field": "https://raw.githubusercontent.com/marqo-ai/marqo/mainline/examples/ImageSearchGuide/data/image2.jpg",
+                 # 4 fields
+                 "multiply_1": 1,
+                 "multiply_2": 20.0,
+                 "add_1": 1.0,
+                 "add_2": 30.0,
+                 "_id": "1"
+                 },
+                {"my_text_field": "A rider is riding a horse jumping over the barrier.",
+                 "my_image_field": "https://raw.githubusercontent.com/marqo-ai/marqo/mainline/examples/ImageSearchGuide/data/image2.jpg",
+                 "_id": "0",
+                 "filter": "original"
+                 },
+            ], non_tensor_fields=["multiply_1", "multiply_2", "add_1", "add_2",
+                                                       "filter"]
+        )
+
+        self.query = "what is the rider doing?"
+
+    def tearDown(self) -> None:
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+
+    def test_score_modifier_search_results(self):
+        score_modifiers = {
+                # miss one weight
+                "multiply_score_by":
+                    [{"field_name": "multiply_1",
+                      "weight": 1,},
+                     {"field_name": "multiply_2",}],
+                "add_to_score": [
+                    {"field_name": "add_1", "weight" : -3,
+                     },
+                    {"field_name": "add_2", "weight": 1,
+                     }]
+            },
+
+        original_res = self.client.index(self.index_name_1).search(q = self.query, score_modifiers=None,
+                                                                     filter_string="filter:original")
+        original_score = original_res["hits"][0]["_score"]
+
+        if self.IS_MULTI_INSTANCE:
+            self.warm_request(self.client.index(self.index_name_1).search, q = self.query, score_modifiers = score_modifiers)
+        modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=score_modifiers)
+
+        modifiers_score = modifiers_res["hits"][0]["_score"]
+
+        self.assertEqual(original_score * 20 * 1 + 1 * -3 + 30 * 1, modifiers_score)
+
+

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -101,22 +101,26 @@ class TestCustomVectorSearch(MarqoTestCase):
         modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=valid_score_modifiers)
 
     def test_bulk_search_error(self):
-        resp = self.client.bulk_search([{
-            "index": self.index_name_1,
-            "q": "title about some doc",
-            "void-void" : {
-                # typo in multiply score by
-                "multiply_score_bys":
-                    [{"field_name": "multiply_1",
-                      "weight": 1,},
-                     {"field_name": "multiply_2",}],
-                "add_to_score": [
-                    {"field_name": "add_1", "weight" : 4,
-                     },
-                    {"field_name": "add_2", "weight": 1,
-                     }]
-            }
-        }])
+        try:
+            resp = self.client.bulk_search([{
+                "index": self.index_name_1,
+                "q": "title about some doc",
+                "void-void" : {
+                    # typo in multiply score by
+                    "multiply_score_bys":
+                        [{"field_name": "multiply_1",
+                          "weight": 1,},
+                         {"field_name": "multiply_2",}],
+                    "add_to_score": [
+                        {"field_name": "add_1", "weight" : 4,
+                         },
+                        {"field_name": "add_2", "weight": 1,
+                         }]
+                }
+            }])
+            raise AssertionError
+        except MarqoWebError:
+            pass
 
 
 

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -118,7 +118,6 @@ class TestCustomVectorSearch(MarqoTestCase):
                          }]
                 }
             }])
-
             raise AssertionError
         except MarqoWebError:
             pass

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -88,7 +88,7 @@ class TestCustomVectorSearch(MarqoTestCase):
             pass
 
     def test_valid_score_modifiers_format(self):
-        invalid_score_modifiers = {
+        valid_score_modifiers = {
                 # missing one part
                 "add_to_score": [
                     {"field_name": "add_1", "weight" : -3,
@@ -97,7 +97,7 @@ class TestCustomVectorSearch(MarqoTestCase):
                      }]
             }
 
-        modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=invalid_score_modifiers)
+        modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=valid_score_modifiers)
 
 
 

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -67,32 +67,6 @@ class TestCustomVectorSearch(MarqoTestCase):
         expected_sore = original_score * 20 * 1 + 1 * -3 + 30 * 1
         assert abs(expected_sore -modifiers_score) < 1e-5
 
-    def test_score_modifier_search_results(self):
-        score_modifiers = {
-                # miss one weight
-                "multiply_score_by":
-                    [{"field_name": "multiply_1",
-                      "weight": 1,},
-                     {"field_name": "multiply_2",}],
-                "add_to_score": [
-                    {"field_name": "add_1", "weight" : -3,
-                     },
-                    {"field_name": "add_2", "weight": 1,
-                     }]
-            }
-
-        original_res = self.client.index(self.index_name_1).search(q = self.query, score_modifiers=None,
-                                                                     filter_string="filter:original")
-        original_score = original_res["hits"][0]["_score"]
-
-        if self.IS_MULTI_INSTANCE:
-            self.warm_request(self.client.index(self.index_name_1).search, q = self.query, score_modifiers = score_modifiers)
-        modifiers_res = self.client.index(self.index_name_1).search(q=self.query, score_modifiers=score_modifiers)
-
-        modifiers_score = modifiers_res["hits"][0]["_score"]
-        expected_sore = original_score * 20 * 1 + 1 * -3 + 30 * 1
-        assert abs(expected_sore -modifiers_score) < 1e-5
-
     def test_invalid_score_modifiers_format(self):
         invalid_score_modifiers = {
                 # miss one weight

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -3,7 +3,7 @@ from marqo.errors import MarqoApiError, MarqoError, MarqoWebError
 from tests.marqo_test import MarqoTestCase
 
 
-class TestCustomVectorSearch(MarqoTestCase):
+class TestScoreModifierSearch(MarqoTestCase):
 
     def setUp(self) -> None:
         self.client = Client(**self.client_settings)

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -105,7 +105,7 @@ class TestScoreModifierSearch(MarqoTestCase):
             resp = self.client.bulk_search([{
                 "index": self.index_name_1,
                 "q": "title about some doc",
-                "void-void" : {
+                "scoreModifiers" : {
                     # typo in multiply score by
                     "multiply_score_bys":
                         [{"field_name": "multiply_1",

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -69,7 +69,7 @@ class TestCustomVectorSearch(MarqoTestCase):
 
     def test_invalid_score_modifiers_format(self):
         invalid_score_modifiers = {
-                # miss one weight
+                # typo in multiply score by
                 "multiply_score_bys":
                     [{"field_name": "multiply_1",
                       "weight": 1,},


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

score modifiers in py-marqo side

* **What is the current behavior?** (You can also link to an open issue here)
we can't modify score 

* **What is the new behavior (if this is a feature change)?**

users can modify the score based on field values
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
this test is related to https://github.com/marqo-ai/marqo/pull/414

