### PR TITLE
added model_auth to search, bulk_search, and add_docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="0.9.4",
+    version="0.9.5",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/src/marqo/models.py
+++ b/src/marqo/models.py
@@ -22,7 +22,7 @@ class SearchBody(BaseMarqoModel):
     image_download_headers: Optional[Dict] = None
     context: Optional[Dict] = None
     scoreModifiers: Optional[Dict] = None
-
+    modelAuth: Optional[Dict] = None
 
 class BulkSearchBody(SearchBody):
     index: str

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,5 +1,5 @@
-__marqo_version__ = "0.0.18"
-__marqo_release_page__ = "https://github.com/marqo-ai/marqo/releases/tag/0.0.18"
+__marqo_version__ = "0.0.19"
+__marqo_release_page__ = "https://github.com/marqo-ai/marqo/releases/tag/0.0.19"
 
 
 def supported_marqo_version() -> str:

--- a/tests/v0_tests/test_model_auth.py
+++ b/tests/v0_tests/test_model_auth.py
@@ -1,0 +1,93 @@
+import json
+from marqo.client import Client
+from marqo.errors import MarqoApiError, MarqoError, MarqoWebError
+from tests.marqo_test import MarqoTestCase
+from marqo.utils import convert_dict_to_url_params
+from unittest import mock
+
+
+class TestAddDocuments(MarqoTestCase):
+
+    def setUp(self) -> None:
+        self.client = Client(**self.client_settings)
+        self.index_name_1 = "my-test-index-1"
+        try:
+            self.client.delete_index(self.index_name_1)
+        except MarqoApiError as s:
+            pass
+
+    def test_add_docs_model_auth(self):
+        mock__post = mock.MagicMock()
+
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            mock_s3_model_auth = {'s3': {'aws_access_key_id': 'some_acc_key',
+                                         'aws_secret_access_key': 'some_sec_acc_key'}}
+            expected_str = f"&model_auth={convert_dict_to_url_params(mock_s3_model_auth)}"
+            self.client.index(index_name=self.index_name_1).add_documents(
+                documents=[{"some": "data"}], model_auth=mock_s3_model_auth)
+            args, kwargs = mock__post.call_args
+            assert expected_str in kwargs['path']
+
+            return True
+
+        assert run()
+
+    def test_add_docs_model_client_batching(self):
+        mock__post = mock.MagicMock()
+
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            mock_s3_model_auth = {'s3': {'aws_access_key_id': 'some_acc_key',
+                                         'aws_secret_access_key': 'some_sec_acc_key'}}
+            expected_str = f"&model_auth={convert_dict_to_url_params(mock_s3_model_auth)}"
+            self.client.index(index_name=self.index_name_1).add_documents(
+                documents=[{"some": f"data {i}"} for i in range(20)], model_auth=mock_s3_model_auth,
+                client_batch_size=10
+            )
+            for call in mock__post.call_args_list:
+                _, kwargs = call
+                assert expected_str in kwargs['path'] or ('refresh' in kwargs['path'])
+
+            assert len(mock__post.call_args_list) == 3
+
+            return True
+
+        assert run()
+
+    def test_search_model_auth(self):
+        mock__post = mock.MagicMock()
+
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            mock_s3_model_auth = {'s3': {'aws_access_key_id': 'some_acc_key',
+                                         'aws_secret_access_key': 'some_sec_acc_key'}}
+            self.client.index(index_name=self.index_name_1).search(
+                q='something', model_auth=mock_s3_model_auth)
+            args, kwargs = mock__post.call_args
+            assert kwargs['body']['modelAuth'] == mock_s3_model_auth
+
+            return True
+
+        assert run()
+
+    def test_bulk_search_model_auth(self):
+        mock__post = mock.MagicMock()
+
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            mock_s3_model_auth = {'s3': {'aws_access_key_id': 'some_acc_key',
+                                         'aws_secret_access_key': 'some_sec_acc_key'}}
+
+            self.client.bulk_search([{
+                "index": self.index_name_1,
+                "q": "a",
+                "modelAuth": mock_s3_model_auth
+            }])
+
+            args, kwargs = mock__post.call_args
+            assert json.loads( kwargs['body'])['queries'][0]['modelAuth'] == mock_s3_model_auth
+
+            return True
+
+        assert run()


### PR DESCRIPTION
including client batching.
Added tests
tox tests pass  

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature. Supporting Marqo's stateless model auth: https://github.com/marqo-ai/marqo/pull/460

* **What is the current behavior?** (You can also link to an open issue here)
The Python client won't let model authorisation propagate to Marqo

* **What is the new behavior (if this is a feature change)?**
The Python client will let model authorisation propagate to Marqo

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

