### PR TITLE
Bulk search now supports context and score modifiers

### DIFF
--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -12,22 +12,25 @@ from marqo.errors import (
 
 HTTP_OPERATIONS = Literal["delete", "get", "post", "put"]
 ALLOWED_OPERATIONS: Tuple[HTTP_OPERATIONS, ...] = get_args(HTTP_OPERATIONS)
+session = requests.Session()
 
-OPERATION_MAPPING = {'delete': lambda s: s.delete, 'get': lambda s: s.get,
-                     'post': lambda s: s.post, 'put': lambda s: s.put}
-
+OPERATION_MAPPING = {
+    'delete': session.delete,
+    'get': session.get,
+    'post': session.post,
+    'put': session.put
+}
 
 class HttpRequests:
-    def __init__(self, config: Config, s: requests.session = requests.Session()) -> None:
+    def __init__(self, config: Config) -> None:
         self.config = config
-        self.session = s
         self.headers = {'x-api-key': config.api_key} if config.api_key else {}
 
     def _operation(self, method: HTTP_OPERATIONS) -> Callable:
         if method not in ALLOWED_OPERATIONS:
             raise ValueError("{} not an allowed operation {}".format(method, ALLOWED_OPERATIONS))
 
-        return OPERATION_MAPPING[method](self.session)
+        return OPERATION_MAPPING[method]
 
     def send_request(
         self,
@@ -38,7 +41,7 @@ class HttpRequests:
     ) -> Any:
         req_headers = copy.deepcopy(self.headers)
 
-        if content_type:
+        if content_type is not None and content_type
             req_headers['Content-Type'] = content_type
 
         if not isinstance(body, (bytes, str)) and body is not None:

--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -41,7 +41,7 @@ class HttpRequests:
     ) -> Any:
         req_headers = copy.deepcopy(self.headers)
 
-        if content_type is not None and content_type
+        if content_type is not None and content_type:
             req_headers['Content-Type'] = content_type
 
         if not isinstance(body, (bytes, str)) and body is not None:

--- a/src/marqo/models.py
+++ b/src/marqo/models.py
@@ -26,9 +26,6 @@ class SearchBody(BaseMarqoModel):
 
 class BulkSearchBody(SearchBody):
     index: str
-    # Attributes that are not supported in bulk search
-    context: None = None
-    scoreModifiers: None = None
 
 
 class BulkSearchQuery(BaseMarqoModel):

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -3,14 +3,105 @@
 
 Pass its settings to local_marqo_settings.
 """
-import unittest
+from collections import defaultdict
+from functools import wraps
+import json
+import os
+from pydantic import BaseModel
+from typing import Any, Callable, Dict, List, Optional, Union
+from unittest import mock, TestCase
+
 from marqo.utils import construct_authorized_url
+from marqo._httprequests import HTTP_OPERATIONS
 from marqo.version import __marqo_version__ as py_marqo_support_version
 from marqo.client import Client
-import os
-import time
+from marqo.errors import InternalError
 
-class MarqoTestCase(unittest.TestCase):
+
+class MockHTTPTraffic(BaseModel):
+    # Request parameters
+    http_operation: HTTP_OPERATIONS
+    path: str
+    body: Optional[Any] = None
+    content_type: Optional[str] = None
+
+    # Verification parameters
+    response: Optional[Union[Any, InternalError]]
+    expected_calls: Optional[int] = None
+
+    class Config:
+        arbitrary_types_allowed: bool = True
+
+    def __str__(self):
+        return f"MockHTTPTraffic({json.dumps(self.dict(), indent=2)})"
+
+def raise_(ex):
+    raise ex
+
+def mock_http_traffic(mock_config: List[MockHTTPTraffic], forbid_extra_calls: bool = False):
+    """Function decorator to mock HTTP traffic to the Marqo instance. Can either return a dictionary, or raise an Exception."""
+    def decorator(test_func):
+        @wraps(test_func)
+        def wrapper(self, *args, **kwargs):
+            call_count = defaultdict(int)  # Used to ensure expected_calls for each MockHTTPTraffic
+
+            with mock.patch("marqo._httprequests.HttpRequests.send_request") as mock_send_request:
+                def side_effect(http_operation, path, body=None, content_type=None):
+                    if isinstance(body, str):
+                        body = json.loads(body)
+
+                    for i, config in enumerate(mock_config):
+                        if http_operation == config.http_operation and path == config.path and body == config.body and content_type == config.content_type:
+                            response = config.response if config.response else {}
+                            call_count[i] += 1
+
+                            if isinstance(response, InternalError):
+                                raise response
+                            return response
+
+                    if forbid_extra_calls:
+                        raise ValueError(
+                            f"Unexpected HTTP call to Marqo. Request (\n"
+                            f"  http_operation={http_operation},\n"
+                            f"  path={path},\n"
+                            f"  body={body},\n"
+                            f"  content_type={content_type}\n"
+                        )
+                mock_send_request.side_effect = side_effect
+
+                test_func(self, *args, **kwargs)
+            
+                for i, config in enumerate(mock_config):
+                    if config.expected_calls is not None and call_count[i] != config.expected_calls:
+                        raise ValueError(f"Expected config to be called {config.expected_calls} times, but it was called {call_count[i]} times, for config: {config}")
+
+        return wrapper
+    return decorator
+
+
+def with_documents(index_to_documents_fn: Callable[[], Dict[str, List[Dict[str, Any]]]], warmup_query: Optional[str] = None):
+    def decorator(test_func):
+        @wraps(test_func)
+        def wrapper(self, *args, **kwargs):
+            index_to_documents = index_to_documents_fn(self)
+            new_args = list(args)
+            for index_name, docs in index_to_documents.items():
+                if len(docs) == 0:
+                    continue
+                self.client.create_index(index_name=index_name)
+                self.client.index(index_name).add_documents(docs)
+                if self.IS_MULTI_INSTANCE:
+                    self.warm_request(self.client.bulk_search, [{
+                        "index": index_name,
+                        "q": list(docs[0].values())[0] if not warmup_query else warmup_query
+                    }])
+                new_args.append(docs)
+            return test_func(self, *new_args, **kwargs)
+        return wrapper
+    return decorator
+
+
+class MarqoTestCase(TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests/v0_tests/test_bulk_search.py
+++ b/tests/v0_tests/test_bulk_search.py
@@ -1,13 +1,14 @@
 import copy
 import marqo
 from marqo import enums
+from typing import Any, Callable, Dict, List, Optional, Union
 from unittest import mock
 from marqo.client import Client
 from marqo.errors import InvalidArgError, MarqoApiError
 import requests
 import random
 import math
-from tests.marqo_test import MarqoTestCase
+from tests.marqo_test import mock_http_traffic, with_documents, MockHTTPTraffic, MarqoTestCase
 
 
 class TestBulkSearch(MarqoTestCase):
@@ -36,24 +37,109 @@ class TestBulkSearch(MarqoTestCase):
 
         return copied
 
-    def test_search_single(self):
-        """Searches an index of a single doc.
-        Checks the basic functionality and response structure"""
-        self.client.create_index(index_name=self.index_name_1)
-        d1 = {
-            "Title": "This is a title about some doc. ",
-            "Description": """The Guardian is a British daily newspaper. It was founded in 1821 as The Manchester Guardian, and changed its name in 1959.[5] Along with its sister papers The Observer and The Guardian Weekly, The Guardian is part of the Guardian Media Group, owned by the Scott Trust.[6] The trust was created in 1936 to "secure the financial and editorial independence of The Guardian in perpetuity and to safeguard the journalistic freedom and liberal values of The Guardian free from commercial or political interference".[7] The trust was converted into a limited company in 2008, with a constitution written so as to maintain for The Guardian the same protections as were built into the structure of the Scott Trust by its creators. Profits are reinvested in journalism rather than distributed to owners or shareholders.[7] It is considered a newspaper of record in the UK.[8][9]
-            The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
-            """
-        }
-        add_doc_res = self.client.index(self.index_name_1).add_documents([d1])
+    @mock_http_traffic([
+        MockHTTPTraffic(
+            http_operation="post",
+            path="indexes/bulk/search?device=cpu",
+            content_type='application/json',
+            body={
+                "queries": [
+                    {
+                        "q": "title about some doc",
+                        "searchableAttributes": None,
+                        "searchMethod": "TENSOR",
+                        "limit": 10,
+                        "offset": 0,
+                        "showHighlights": True,
+                        "reRanker": None,
+                        "filter": None,
+                        "attributesToRetrieve": None,
+                        "boost": None,
+                        "image_download_headers": None,
+                        "context": {
+                            "tensor": [
+                                {"vector": [1, 1, 1], "weight": 0},
+                                {"vector": [2, 2], "weight": 0}
+                            ]
+                        },
+                        "scoreModifiers": None,
+                        "modelAuth": None,
+                        "index": "my-test-index-1"
+                    }
+                ]
+            }
+        )
+    ], forbid_extra_calls=True)
+    def test_bulk_search_with_context(self):
+        """Check that context is passed to HTTP request correctly"""
+        self.client.bulk_search([{
+            "index": self.index_name_1,
+            "q": "title about some doc",
+            "context": {"tensor": [{"vector": [1, ] * 3, "weight": 0}, {"vector": [2, ] * 2, "weight": 0}], }
+        }])
 
-        if self.IS_MULTI_INSTANCE:
-            self.warm_request(self.client.bulk_search, [{
-                "index": self.index_name_1,
-                "q": "title about some doc"
-            }])
 
+    @mock_http_traffic([
+        MockHTTPTraffic(
+            http_operation="post",
+            path="indexes/bulk/search?device=cpu",
+            content_type='application/json',
+            body={
+                "queries": [
+                    {
+                        "q": "title about some doc",
+                        "searchableAttributes": None,
+                        "searchMethod": "TENSOR",
+                        "limit": 10,
+                        "offset": 0,
+                        "showHighlights": True,
+                        "reRanker": None,
+                        "filter": None,
+                        "attributesToRetrieve": None,
+                        "boost": None,
+                        "image_download_headers": None,
+                        "context": None,
+                        "scoreModifiers": {
+                            "multiply_score_by": [
+                                {"field_name": "multiply_1", "weight": 1,},
+                                {"field_name": "multiply_2",}
+                            ],
+                            "add_to_score": [
+                                {"field_name": "add_1", "weight" : -3},
+                                {"field_name": "add_2", "weight": 1}
+                            ]
+                        },
+                        "modelAuth": None,
+                        "index": "my-test-index-1"
+                    }
+                ]
+            }
+        )
+    ], forbid_extra_calls=True)
+    def test_bulk_search_with_scoreModifiers(self):
+        """Check that context is passed to HTTP request correctly"""
+        self.client.bulk_search([{
+            "index": self.index_name_1,
+            "q": "title about some doc",
+            "scoreModifiers": {
+                "multiply_score_by": [
+                    {"field_name": "multiply_1", "weight": 1,},
+                    {"field_name": "multiply_2",}
+                ],
+                "add_to_score": [
+                    {"field_name": "add_1", "weight" : -3},
+                    {"field_name": "add_2", "weight": 1}
+                ]
+            }
+        }])
+
+    @with_documents(lambda self: {self.index_name_1: [{
+        "Title": "This is a title about some doc. ",
+        "Description": """The Guardian is a British daily newspaper. It was founded in 1821 as The Manchester Guardian, and changed its name in 1959.[5] Along with its sister papers The Observer and The Guardian Weekly, The Guardian is part of the Guardian Media Group, owned by the Scott Trust.[6] The trust was created in 1936 to "secure the financial and editorial independence of The Guardian in perpetuity and to safeguard the journalistic freedom and liberal values of The Guardian free from commercial or political interference".[7] The trust was converted into a limited company in 2008, with a constitution written so as to maintain for The Guardian the same protections as were built into the structure of the Scott Trust by its creators. Profits are reinvested in journalism rather than distributed to owners or shareholders.[7] It is considered a newspaper of record in the UK.[8][9]
+        The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
+        """
+    }]}, warmup_query="title about some doc")
+    def test_bulk_search_single(self, index_1_docs: List[Dict[str, Any]]):
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
             "q": "title about some doc"
@@ -62,9 +148,9 @@ class TestBulkSearch(MarqoTestCase):
         search_res = resp['result'][0]
 
         assert len(search_res["hits"]) == 1
-        assert self.strip_marqo_fields(search_res["hits"][0]) == d1
+        assert self.strip_marqo_fields(search_res["hits"][0]) == index_1_docs[0]
         assert len(search_res["hits"][0]["_highlights"]) > 0
-        assert ("Title" in search_res["hits"][0]["_highlights"]) or ("Description" in search_res["hits"][0]["_highlights"])
+        assert {"Title", "Description"} & set(search_res["hits"][0]["_highlights"])
 
     def test_search_empty_index(self):
         self.client.create_index(index_name=self.index_name_1)
@@ -111,28 +197,16 @@ class TestBulkSearch(MarqoTestCase):
             search_res = resp['result'][0]
             assert ("_highlights" in search_res["hits"][0]) is expected_highlights_presence
 
-    def test_search_multi(self):
-        self.client.create_index(index_name=self.index_name_1)
-        d1 = {
-                "doc title": "Cool Document 1",
-                "field 1": "some extra info",
-                "_id": "e197e580-0393-4f4e-90e9-8cdf4b17e339"
-            }
-        d2 = {
-                "doc title": "Just Your Average Doc",
-                "field X": "this is a solid doc",
-                "_id": "123456"
-        }
-        res = self.client.index(self.index_name_1).add_documents([
-            d1, d2
-        ])
-
-        if self.IS_MULTI_INSTANCE:
-            self.warm_request(self.client.bulk_search, [{
-                "index": self.index_name_1,
-                "q": "this is a solid doc"
-            }])
-
+    @with_documents(lambda self: {self.index_name_1: [{
+            "doc title": "Cool Document 1",
+            "field 1": "some extra info",
+            "_id": "e197e580-0393-4f4e-90e9-8cdf4b17e339"
+        },{
+            "doc title": "Just Your Average Doc",
+            "field X": "this is a solid doc",
+            "_id": "123456"
+    }]}, warmup_query="this is a solid doc")
+    def test_bulk_search_multi(self, index_1_docs):
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
             "q": "this is a solid doc"
@@ -140,32 +214,20 @@ class TestBulkSearch(MarqoTestCase):
         assert len(resp['result']) == 1
         search_res = resp['result'][0]
 
-        assert d2 == self.strip_marqo_fields(search_res['hits'][0], strip_id=False)
+        assert index_1_docs[1] == self.strip_marqo_fields(search_res['hits'][0], strip_id=False)
         assert search_res['hits'][0]['_highlights']["field X"] == "this is a solid doc"
 
-    def test_select_lexical(self):
-        self.client.create_index(index_name=self.index_name_1)
-        d1 = {
+    @with_documents(lambda self: {self.index_name_1: [{
             "doc title": "Very heavy, dense metallic lead.",
             "field 1": "some extra info",
             "_id": "e197e580-0393-4f4e-90e9-8cdf4b17e339"
-        }
-        d2 = {
+        },{
             "doc title": "The captain bravely lead her followers into battle."
                          " She directed her soldiers to and fro.",
             "field X": "this is a solid doc",
             "_id": "123456"
-        }
-        res = self.client.index(self.index_name_1).add_documents([
-            d1, d2
-        ])
-
-        if self.IS_MULTI_INSTANCE:
-            self.warm_request(self.client.bulk_search, [{
-                "index": self.index_name_1,
-                "q": "Examples of leadership"
-            }])
-
+        }]}, warmup_query="Examples of leadership")
+    def test_select_lexical(self, index_1_docs):
         # Ensure that vector search works
         resp = self.client.bulk_search([{
             "index": self.index_name_1,
@@ -174,7 +236,7 @@ class TestBulkSearch(MarqoTestCase):
         assert len(resp['result']) == 1
         search_res = resp['result'][0]
 
-        assert d2 == self.strip_marqo_fields(search_res["hits"][0], strip_id=False)
+        assert index_1_docs[1] == self.strip_marqo_fields(search_res["hits"][0], strip_id=False)
         assert search_res["hits"][0]['_highlights']["doc title"].startswith("The captain bravely lead her followers")
 
         # try it with lexical search:

--- a/tests/v0_tests/test_bulk_search.py
+++ b/tests/v0_tests/test_bulk_search.py
@@ -4,7 +4,7 @@ from marqo import enums
 from typing import Any, Callable, Dict, List, Optional, Union
 from unittest import mock
 from marqo.client import Client
-from marqo.errors import InvalidArgError, MarqoApiError
+from marqo.errors import InvalidArgError, MarqoApiError, MarqoWebError
 import requests
 import random
 import math
@@ -447,3 +447,51 @@ class TestBulkSearch(MarqoTestCase):
             # the poodle doc should be lower ranked than the irrelevant doc
             for hit_position, _ in enumerate(res['hits']):
                 assert res['hits'][hit_position]['_id'] == expected_ordering[hit_position]
+
+    def test_score_modifiers_in_bulk_search_end_to_end(self):
+        self.client.create_index(index_name=self.index_name_1)
+        d1 = {
+            "doc title": "Very heavy, dense metallic lead.",
+            "abc-123": "some text blah",
+            "multiply": 2,
+            "add": 1,
+            "_id": "my-cool-doc"
+        }
+        d2 = {
+            "doc title": "The captain bravely lead her followers into battle."
+                         " She directed her soldiers to and fro.",
+            "field X": "this is a solid doc blah",
+            "field1": "other things",
+            "multiply": 2,
+            "add": 1,
+            "_id": "123456"
+        }
+        x = self.client.index(self.index_name_1).add_documents([
+            d1, d2
+        ], auto_refresh=True)
+
+        score_modifiers = {
+            "multiply_score_by":[{"field_name": "multiply", "weight": 1}],
+            "add_to_score": [{"field_name": "add", "weight": 2}]
+        }
+
+        for search_method in [enums.SearchMethods.TENSOR]:
+            if self.IS_MULTI_INSTANCE:
+                self.warm_request(self.client.bulk_search, [{
+                    "index": self.index_name_1,
+                    "q": "blah blah",
+                    "searchMethod": search_method,
+                }])
+
+            resp = self.client.bulk_search([{
+                "index": self.index_name_1,
+                "q": "blah blah",
+                "searchMethod": search_method,
+                "scoreModifiers": score_modifiers,
+            }])
+            assert len(resp['result']) == 1
+            search_res = resp['result'][0]
+
+            assert len(search_res['hits']) == 2
+            for hit in search_res['hits']:
+                assert hit["_score"] > 2

--- a/tests/v0_tests/test_custom_vector_search.py
+++ b/tests/v0_tests/test_custom_vector_search.py
@@ -143,3 +143,39 @@ class TestCustomBulkVectorSearch(TestCustomVectorSearch):
             return resp['result'][0]
         return {}
 
+    def test_context_dimension_error_in_bulk_search(self):
+        correct_context = {"tensor": [{"vector": [1, ] * 384, "weight": 1}, {"vector": [2, ] * 384, "weight": 0}]}
+        wrong_context = {"tensor": [{"vector": [1, ] * 2, "weight": 1}, {"vector": [2, ] * 3, "weight": 0}]}
+        if self.IS_MULTI_INSTANCE:
+            self.warm_request(self.client.bulk_search, [{
+                "index": self.index_name_1,
+                "q": "blah blah",
+                "context": correct_context,
+            }])
+        try:
+            resp = self.client.bulk_search([{
+                "index": self.index_name_1,
+                "q": {"blah blah": 1},
+                "context": wrong_context, # the dimension mismatches the index
+            }])
+            raise AssertionError
+        except MarqoWebError as e:
+            assert "The provided vectors are not in the same dimension of the index" in str(e)
+
+    def test_context_with_query_string_in_bulk_search(self):
+        correct_context = {"tensor": [{"vector": [1, ] * 384, "weight": 1}, {"vector": [2, ] * 384, "weight": 0}]}
+        if self.IS_MULTI_INSTANCE:
+            self.warm_request(self.client.bulk_search, [{
+                "index": self.index_name_1,
+                "q": "blah blah",
+                "context": correct_context,
+            }])
+        try:
+            resp = self.client.bulk_search([{
+                "index": self.index_name_1,
+                "q": "blah blah",
+                "context": correct_context, # the dimension mismatches the index
+            }])
+            raise AssertionError
+        except MarqoWebError as e:
+            assert "This is not supported as the context only works when the query is a dictionary." in str(e)

--- a/tests/v0_tests/test_custom_vector_search.py
+++ b/tests/v0_tests/test_custom_vector_search.py
@@ -97,8 +97,8 @@ class TestCustomVectorSearch(MarqoTestCase):
             pass
 
     def test_context_dimension_have_different_dimensions_to_index(self):
-         correct_context = {"tensor": [{"vector": [1, ] * 384, "weight": 1}, {"vector": [2, ] * 384, "weight": 0}]}
-         wrong_context = {"tensor": [{"vector": [1, ] * 2, "weight": 1}, {"vector": [2, ] * 3, "weight": 0}]}
+         correct_context = {"tensor": [{"vector": [1, ] * 384, "weight": 1}]}
+         wrong_context = {"tensor": [{"vector": [1, ] * 2, "weight": 1}]}
          if self.IS_MULTI_INSTANCE:
              self.warm_request(lambda _: self.search_with_context(correct_context))
          try:
@@ -107,6 +107,29 @@ class TestCustomVectorSearch(MarqoTestCase):
          except MarqoWebError as e:
             assert "The provided vectors are not in the same dimension of the index" in str(e)
 
+    def test_context_dimension_have_inconsistent_dimensions(self):
+         correct_context = {"tensor": [{"vector": [1, ] * 384, "weight": 1}, {"vector": [2, ] * 384, "weight": 0}]}
+         wrong_context = {"tensor": [{"vector": [1, ] * 384, "weight": 1}, {"vector": [2, ] * 385, "weight": 0}]}
+         if self.IS_MULTI_INSTANCE:
+             self.warm_request(lambda _: self.search_with_context(correct_context))
+         try:
+             self.search_with_context(wrong_context)
+             raise AssertionError
+         except MarqoWebError as e:
+            assert "The provided vectors are not in the same dimension of the index" in str(e)
+
+    def test_context_vector_with_flat_query(self):
+        self.query = "What are the best pets"
+        context = {"tensor": [{"vector": [1, ] * 384, "weight": 1}, {"vector": [2, ] * 384, "weight": 0}]}
+        try:
+            result = self.search_with_context(context)
+            raise AssertionError(f"The query should not be accepted. Returned: {result}")
+        except MarqoWebError as e:
+            assert "This is not supported as the context only works when the query is a dictionary." in str(e)
+        finally:
+
+            ## Ensure other tests are not affected
+            self.query = {"What are the best pets": 1}
 
 class TestCustomBulkVectorSearch(TestCustomVectorSearch):
 

--- a/tests/v0_tests/test_custom_vector_search.py
+++ b/tests/v0_tests/test_custom_vector_search.py
@@ -96,6 +96,17 @@ class TestCustomVectorSearch(MarqoTestCase):
         except MarqoWebError:
             pass
 
+    def test_context_dimension_have_different_dimensions_to_index(self):
+         correct_context = {"tensor": [{"vector": [1, ] * 384, "weight": 1}, {"vector": [2, ] * 384, "weight": 0}]}
+         wrong_context = {"tensor": [{"vector": [1, ] * 2, "weight": 1}, {"vector": [2, ] * 3, "weight": 0}]}
+         if self.IS_MULTI_INSTANCE:
+             self.warm_request(lambda _: self.search_with_context(correct_context))
+         try:
+             self.search_with_context(wrong_context)
+             raise AssertionError
+         except MarqoWebError as e:
+            assert "The provided vectors are not in the same dimension of the index" in str(e)
+
 
 class TestCustomBulkVectorSearch(TestCustomVectorSearch):
 

--- a/tests/v0_tests/test_custom_vector_search.py
+++ b/tests/v0_tests/test_custom_vector_search.py
@@ -149,7 +149,7 @@ class TestCustomBulkVectorSearch(TestCustomVectorSearch):
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.bulk_search, [{
                 "index": self.index_name_1,
-                "q": "blah blah",
+                "q": {"blah blah" :1},
                 "context": correct_context,
             }])
         try:
@@ -167,7 +167,7 @@ class TestCustomBulkVectorSearch(TestCustomVectorSearch):
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.bulk_search, [{
                 "index": self.index_name_1,
-                "q": "blah blah",
+                "q": {"blah blah" :1},
                 "context": correct_context,
             }])
         try:


### PR DESCRIPTION
Client side support for [PR #469](https://github.com/marqo-ai/marqo/pull/469). Enabled the following in bulk search: 
1. Context vectors
2. Score modifiers
