### PR TITLE
Fix warm up tests in search test suites

### DIFF
--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -34,7 +34,6 @@ class TestScoreModifierSearch(MarqoTestCase):
             ], non_tensor_fields=["multiply_1", "multiply_2", "add_1", "add_2",
                                                        "filter"]
         )
-
         self.query = "what is the rider doing?"
 
     def tearDown(self) -> None:
@@ -65,13 +64,13 @@ class TestScoreModifierSearch(MarqoTestCase):
             }
 
         if self.IS_MULTI_INSTANCE:
-            self.warm_request(lambda _: self.search_with_score_modifier(score_modifiers=None, filter_string="filter:original"))
+            self.warm_request(lambda: self.search_with_score_modifier(score_modifiers=None, filter_string="filter:original"))
         
         original_res = self.search_with_score_modifier(score_modifiers=None, filter_string="filter:original")
         original_score = original_res["hits"][0]["_score"]
 
         if self.IS_MULTI_INSTANCE:
-            self.warm_request(lambda _: self.search_with_score_modifier(score_modifiers=score_modifiers))
+            self.warm_request(lambda: self.search_with_score_modifier(score_modifiers=score_modifiers))
         modifiers_res = self.search_with_score_modifier(score_modifiers=score_modifiers)
 
         modifiers_score = modifiers_res["hits"][0]["_score"]


### PR DESCRIPTION
## Changeset
  - Fix search tests when `IS_MULTI_INSTANCE`
  - Change in vector dimension is required for correct testing.

## Testing
 - Explicitly overrode [cls.IS_MULTI_INSTANCE](https://github.com/marqo-ai/py-marqo/blob/mainline/tests/marqo_test.py#L119) to both True and False.