### PR TITLE
Changes to tests to prevent leftover test indexes

### DIFF
--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -3,6 +3,7 @@
 
 Pass its settings to local_marqo_settings.
 """
+import logging
 from collections import defaultdict
 from functools import wraps
 import json
@@ -136,8 +137,8 @@ class MarqoTestCase(TestCase):
         for ix_name in indexes_to_tear_down:
             try:
                 client.delete_index(ix_name)
-            except marqo.errors.MarqoApiError:
-                pass
+            except marqo.errors.MarqoApiError as e:
+                logging.debug(f'received error `{e}` from index deletion request.')
 
     def warm_request(self, func, *args, **kwargs):
         '''

--- a/tests/v0_tests/test_demos.py
+++ b/tests/v0_tests/test_demos.py
@@ -189,7 +189,7 @@ class TestDemo(MarqoTestCase):
     def test_readme_example_multimodal_combination_query(self):
         import marqo
         mq = marqo.Client(**self.client_settings)
-        settings = {"treat_urls_and_pointers_as_images": True, "model": "ViT-L/14"}
+        settings = {"treat_urls_and_pointers_as_images": True, "model": "ViT-B/32"}
         mq.create_index("my-first-multimodal-index", **settings)
         mq.index("my-first-multimodal-index").add_documents(
             [

--- a/tests/v0_tests/test_image_chunking.py
+++ b/tests/v0_tests/test_image_chunking.py
@@ -16,7 +16,7 @@ class TestImageChunking(MarqoTestCase):
     def setUp(self) -> None:
         client_0 = Client(**self.client_settings)
         
-        self.index_name = 'image-chunk-test'
+        self.index_name = 'test-index'
 
         try:
             client_0.delete_index(self.index_name)

--- a/tests/v0_tests/test_image_chunking.py
+++ b/tests/v0_tests/test_image_chunking.py
@@ -16,7 +16,7 @@ class TestImageChunking(MarqoTestCase):
     def setUp(self) -> None:
         client_0 = Client(**self.client_settings)
         
-        self.index_name = 'test-index'
+        self.index_name = self.generic_test_index_name
 
         try:
             client_0.delete_index(self.index_name)

--- a/tests/v0_tests/test_sentence_chunking.py
+++ b/tests/v0_tests/test_sentence_chunking.py
@@ -18,7 +18,7 @@ class TestSentenceChunking(MarqoTestCase):
     def setUp(self) -> None:
         client_0 = Client(**self.client_settings)
         
-        self.index_name = 'sentence-chunk-test'
+        self.index_name = 'test-index'
 
         try:
             client_0.delete_index(self.index_name)

--- a/tests/v0_tests/test_sentence_chunking.py
+++ b/tests/v0_tests/test_sentence_chunking.py
@@ -18,7 +18,7 @@ class TestSentenceChunking(MarqoTestCase):
     def setUp(self) -> None:
         client_0 = Client(**self.client_settings)
         
-        self.index_name = 'test-index'
+        self.index_name = self.generic_test_index_name
 
         try:
             client_0.delete_index(self.index_name)


### PR DESCRIPTION
Changes added to prevent dangling indexes created during testing.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Tests update

* **What is the current behavior?** (You can also link to an open issue here)
Some indexes aren't torn down properly after testing is complete

* **What is the new behavior (if this is a feature change)?**
All indexes are torn down properly after testing is complete. Testing done against the cloud confirms this.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:
- tests pass against local Marqo instance, and confirmed that no indexes remained
- tested on the cloud, confirmed that no indexes remained 




