### PR TITLE
Add as optional parameter to Marqo client

### DIFF
--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -32,6 +32,13 @@ class HttpRequests:
 
         return OPERATION_MAPPING[method]
 
+    def construct_path(self, path: str) -> str:
+        """Augment the URL request path based if telemetry is required."""
+        if self.config.use_telemetry:
+            delimeter= "?" if "?" not in f"{self.config.url}/{path}" else "&"
+            return f"{self.config.url}/{path}{delimeter}telemetry=True"
+        return f"{self.config.url}/{path}"
+
     def send_request(
         self,
         http_operation: HTTP_OPERATIONS,
@@ -49,7 +56,7 @@ class HttpRequests:
 
         try:
             response = self._operation(http_operation)(
-                url=f"{self.config.url}/{path}",
+                url=self.construct_path(path),
                 timeout=self.config.timeout,
                 headers=req_headers,
                 data=body,

--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -32,7 +32,7 @@ class HttpRequests:
 
         return OPERATION_MAPPING[method]
 
-    def construct_path(self, path: str) -> str:
+    def _construct_path(self, path: str) -> str:
         """Augment the URL request path based if telemetry is required."""
         if self.config.use_telemetry:
             delimeter= "?" if "?" not in f"{self.config.url}/{path}" else "&"
@@ -56,7 +56,7 @@ class HttpRequests:
 
         try:
             response = self._operation(http_operation)(
-                url=self.construct_path(path),
+                url=self._construct_path(path),
                 timeout=self.config.timeout,
                 headers=req_headers,
                 data=body,

--- a/src/marqo/client.py
+++ b/src/marqo/client.py
@@ -22,6 +22,7 @@ class Client:
         self, url: str = "http://localhost:8882", main_user: str = None, main_password: str = None,
         indexing_device: Optional[Union[enums.Devices, str]] = None,
         search_device: Optional[Union[enums.Devices, str]] = None,
+        return_telemetry: bool = False,
         api_key: str = None
     ) -> None:
         """
@@ -36,7 +37,7 @@ class Client:
             self.url = utils.construct_authorized_url(url_base=url, username=main_user, password=main_password)
         else:
             self.url = url
-        self.config = Config(self.url, indexing_device=indexing_device, search_device=search_device, api_key=api_key)
+        self.config = Config(self.url, use_telemetry=return_telemetry, indexing_device=indexing_device, search_device=search_device, api_key=api_key)
         self.http = HttpRequests(self.config)
 
     def create_index(

--- a/src/marqo/config.py
+++ b/src/marqo/config.py
@@ -12,6 +12,7 @@ class Config:
     def __init__(
         self,
         url: str,
+        use_telemetry: bool = False,
         timeout: Optional[int] = None,
         indexing_device: Optional[Union[enums.Devices, str]] = None,
         search_device: Optional[Union[enums.Devices, str]] = None,
@@ -34,6 +35,7 @@ class Config:
         self.search_device = search_device if search_device is not None else default_device
         # suppress warnings until we figure out the dependency issues:
         # warnings.filterwarnings("ignore")
+        self.use_telemetry = use_telemetry
 
     def set_url(self, url):
         """Set the URL, and infers whether that url is remote"""

--- a/tests/v0_tests/test__httprequests.py
+++ b/tests/v0_tests/test__httprequests.py
@@ -9,7 +9,7 @@ class TestConstructPath(unittest.TestCase):
 
     def construct_path_helper(self, path, use_telemetry=None):
         r = HttpRequests(config=Config(use_telemetry=use_telemetry, url=self.base_url))
-        return r.construct_path(path)
+        return r._construct_path(path)
 
     def test_construct_path_with_telemetry_enabled(self):
         result = self.construct_path_helper("testpath", True)

--- a/tests/v0_tests/test__httprequests.py
+++ b/tests/v0_tests/test__httprequests.py
@@ -1,0 +1,28 @@
+import unittest
+from marqo._httprequests import HttpRequests
+from marqo.config import Config
+
+class TestConstructPath(unittest.TestCase):
+
+    def setUp(self):
+        self.base_url = "http://localhost:8882"
+
+    def construct_path_helper(self, path, use_telemetry=None):
+        r = HttpRequests(config=Config(use_telemetry=use_telemetry, url=self.base_url))
+        return r.construct_path(path)
+
+    def test_construct_path_with_telemetry_enabled(self):
+        result = self.construct_path_helper("testpath", True)
+        self.assertEqual(result, f"{self.base_url}/testpath?telemetry=True")
+
+    def test_construct_path_with_query_string_and_telemetry_enabled(self):
+        result = self.construct_path_helper("testpath?param=value", True)
+        self.assertEqual(result, f"{self.base_url}/testpath?param=value&telemetry=True")
+
+    def test_construct_path_with_telemetry_disabled(self):
+        result = self.construct_path_helper("testpath", False)
+        self.assertEqual(result, f"{self.base_url}/testpath")
+
+    def test_construct_path_with_no_telemetry_parameter(self):
+        result = self.construct_path_helper("testpath")
+        self.assertEqual(result, f"{self.base_url}/testpath")


### PR DESCRIPTION
## Changeset 
```python
import marqo
import pprint

mq = marqo.Client(url="http://localhost:8882", return_telemetry=true)
mq.index("image-chunk-test").search(
    q="What is the best outfit to wear on the moon?"
)

pprint.pprint(results)

{
    'hits': [
        {   
            'Title': 'Extravehicular Mobility Unit (EMU)',
            'Description': 'The EMU is a spacesuit that provides environmental protection, mobility, life support, and' 
                           'communications for astronauts',
            '_highlights': {
                'Description': 'The EMU is a spacesuit that provides environmental protection, '
                               'mobility, life support, and communications for astronauts'
            },
            '_id': 'article_591',
            '_score': 0.61938936
        }, 
        {   
            'Title': 'The Travels of Marco Polo',
            'Description': "A 13th-century travelogue describing Polo's travels",
            '_highlights': {'Title': 'The Travels of Marco Polo'},
            '_id': 'e00d1a8d-894c-41a1-8e3b-d8b2a8fce12a',
            '_score': 0.60237324
        }
    ],
    'limit': 10,
    'offset': 0,
    'processingTimeMs': 131,
    'query': 'What is the best outfit to wear on the moon?',
    'telemetry': {'timesMs': {'POST /indexes/image-chunk-test/search': 130.58258296223357,
                           'search.create_vectors': 81.41441701445729,
                           'search.opensearch._msearch': 46.959917002823204,
                           'search.opensearch._msearch.internal': 27.0,
                           'search.vector.postprocess': 0.05445897113531828,
                           'search.vector.preprocess': 82.55304204067215,
                           'vector_inference': 77.69075001124293}}}
}
```

## Testing
 - unit tests
 -  Manual testing
 - Similar PR used to run marqo-api-tests.