### PR TITLE
Removing  default device in client (related to Marqo CUDA device PR)

### DIFF
--- a/src/marqo/client.py
+++ b/src/marqo/client.py
@@ -151,10 +151,9 @@ class Client:
         except error_wrappers.ValidationError as e:
             raise errors.InvalidArgError(f"some parameters in search query(s) are invalid. Errors are: {e.errors()}")
 
-        translated = utils.translate_device_string_for_url(device)
-        
+        translated_device_param = f"{f'?&device={utils.translate_device_string_for_url(device)}' if device is not None else ''}"
         return self.http.post(
-            f"indexes/bulk/search?device={translated}",
+            f"indexes/bulk/search{translated_device_param}",
             body=BulkSearchQuery(queries=parsed_queries).json()
         )
 

--- a/src/marqo/client.py
+++ b/src/marqo/client.py
@@ -19,9 +19,8 @@ class Client:
     marqo and its permissions.
     """
     def __init__(
-        self, url: str = "http://localhost:8882", main_user: str = None, main_password: str = None,
-        indexing_device: Optional[Union[enums.Devices, str]] = None,
-        search_device: Optional[Union[enums.Devices, str]] = None,
+        self, url: str = "http://localhost:8882", 
+        main_user: str = None, main_password: str = None,
         api_key: str = None
     ) -> None:
         """
@@ -36,7 +35,7 @@ class Client:
             self.url = utils.construct_authorized_url(url_base=url, username=main_user, password=main_password)
         else:
             self.url = url
-        self.config = Config(self.url, indexing_device=indexing_device, search_device=search_device, api_key=api_key)
+        self.config = Config(self.url, api_key=api_key)
         self.http = HttpRequests(self.config)
 
     def create_index(
@@ -139,8 +138,7 @@ class Client:
 
     def enrich(self, documents: List[Dict], enrichment: Dict, device: str = None, ):
         """Enrich documents"""
-        selected_device = device if device is not None else self.config.indexing_device
-        translated = utils.translate_device_string_for_url(selected_device)
+        translated = utils.translate_device_string_for_url(device)
         response = self.http.post(path=f'enrichment?device={translated}', body={
             "documents": documents,
             "enrichment": enrichment
@@ -153,8 +151,7 @@ class Client:
         except error_wrappers.ValidationError as e:
             raise errors.InvalidArgError(f"some parameters in search query(s) are invalid. Errors are: {e.errors()}")
 
-        selected_device = device if device is not None else self.config.search_device
-        translated = utils.translate_device_string_for_url(selected_device)
+        translated = utils.translate_device_string_for_url(device)
         
         return self.http.post(
             f"indexes/bulk/search?device={translated}",

--- a/src/marqo/config.py
+++ b/src/marqo/config.py
@@ -19,7 +19,7 @@ class Config:
         Parameters
         ----------
         url:
-            The url to the Marqo instance (ex: http://???)
+            The url to the Marqo instance (ex: http://localhost:8882)
         """
         self.cluster_is_remote = False
         self.cluster_is_s2search = False

--- a/src/marqo/config.py
+++ b/src/marqo/config.py
@@ -13,25 +13,19 @@ class Config:
         self,
         url: str,
         timeout: Optional[int] = None,
-        indexing_device: Optional[Union[enums.Devices, str]] = None,
-        search_device: Optional[Union[enums.Devices, str]] = None,
         api_key: str = None
     ) -> None:
         """
         Parameters
         ----------
         url:
-            The url to the S2Search API (ex: http://localhost:9200)
+            The url to the Marqo instance (ex: http://???)
         """
         self.cluster_is_remote = False
         self.cluster_is_s2search = False
         self.url = self.set_url(url)
         self.timeout = timeout
         self.api_key = api_key
-        default_device = enums.Devices.cpu
-
-        self.indexing_device = indexing_device if indexing_device is not None else default_device
-        self.search_device = search_device if search_device is not None else default_device
         # suppress warnings until we figure out the dependency issues:
         # warnings.filterwarnings("ignore")
 

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -157,8 +157,8 @@ class Index:
             show_highlights = highlights if show_highlights is True else show_highlights
 
         path_with_query_str = (
-            f"indexes/{self.index_name}/search?"
-            f"&device={utils.translate_device_string_for_url(device)}"
+            f"indexes/{self.index_name}/search"
+            f"{f'?&device={utils.translate_device_string_for_url(device)}' if device is not None else ''}"
         )
         body = {
             "q": q,
@@ -367,7 +367,7 @@ class Index:
         model_auth_param = (utils.convert_dict_to_url_params(model_auth) if model_auth else '')
         mappings_param = (utils.convert_dict_to_url_params(mappings) if mappings else '')
         query_str_params = (
-            f"{f'&device={utils.translate_device_string_for_url(device)}'}"
+            f"{f'&device={utils.translate_device_string_for_url(device)}' if device is not None else ''}"
             f"{f'&processes={processes}' if processes is not None else ''}"
             f"{f'&batch_size={server_batch_size}' if server_batch_size is not None else ''}"
             f"{f'&use_existing_tensors={str(use_existing_tensors).lower()}' if use_existing_tensors is not None else ''}"

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -137,7 +137,7 @@ class Index:
             show_highlights: True if highlights are to be returned
             reranker:
             device: the device used to index the data. Examples include "cpu",
-                "cuda" and "cuda:2". Overrides the Client's default device.
+                "cuda" and "cuda:2".
             filter_string: a filter string, used to prefilter documents during the
                 search. For example: "car_colour:blue"
             attributes_to_retrieve: a list of document attributes to be
@@ -156,10 +156,9 @@ class Index:
                             "Please use the 'showHighlights' instead. ")
             show_highlights = highlights if show_highlights is True else show_highlights
 
-        selected_device = device if device is not None else self.config.search_device
         path_with_query_str = (
             f"indexes/{self.index_name}/search?"
-            f"&device={utils.translate_device_string_for_url(selected_device)}"
+            f"&device={utils.translate_device_string_for_url(device)}"
         )
         body = {
             "q": q,
@@ -356,7 +355,6 @@ class Index:
         if non_tensor_fields is None:
             non_tensor_fields = []
 
-        selected_device = device if device is not None else self.config.indexing_device
         num_docs = len(documents)
 
         # ADD DOCS TIMER-LOGGER (1)
@@ -369,7 +367,7 @@ class Index:
         model_auth_param = (utils.convert_dict_to_url_params(model_auth) if model_auth else '')
         mappings_param = (utils.convert_dict_to_url_params(mappings) if mappings else '')
         query_str_params = (
-            f"{f'&device={utils.translate_device_string_for_url(selected_device)}'}"
+            f"{f'&device={utils.translate_device_string_for_url(device)}'}"
             f"{f'&processes={processes}' if processes is not None else ''}"
             f"{f'&batch_size={server_batch_size}' if server_batch_size is not None else ''}"
             f"{f'&use_existing_tensors={str(use_existing_tensors).lower()}' if use_existing_tensors is not None else ''}"

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -51,7 +51,6 @@ def mock_http_traffic(mock_config: List[MockHTTPTraffic], forbid_extra_calls: bo
                 def side_effect(http_operation, path, body=None, content_type=None):
                     if isinstance(body, str):
                         body = json.loads(body)
-
                     for i, config in enumerate(mock_config):
                         if http_operation == config.http_operation and path == config.path and body == config.body and content_type == config.content_type:
                             response = config.response if config.response else {}

--- a/tests/v0_tests/test_add_documents.py
+++ b/tests/v0_tests/test_add_documents.py
@@ -226,8 +226,6 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_add_documents_with_device(self):
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = enums.Devices.cpu
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
 
@@ -244,8 +242,6 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_add_documents_with_device_batching(self):
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = enums.Devices.cpu
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)

--- a/tests/v0_tests/test_add_documents.py
+++ b/tests/v0_tests/test_add_documents.py
@@ -255,7 +255,7 @@ class TestAddDocuments(MarqoTestCase):
         for args, kwargs in mock__post.call_args_list[:-1]:
             assert "device=cuda37" in kwargs["path"]
 
-    def test_add_documents_default_device(self):
+    def test_add_documents_device_not_set(self):
         """If no device is set, do not even add device parameter to the API call
         """
         temp_client = copy.deepcopy(self.client)

--- a/tests/v0_tests/test_add_documents.py
+++ b/tests/v0_tests/test_add_documents.py
@@ -256,13 +256,9 @@ class TestAddDocuments(MarqoTestCase):
             assert "device=cuda37" in kwargs["path"]
 
     def test_add_documents_default_device(self):
-        """do we use the default device defined in the client, if it isn't
-        overridden?
+        """If no device is set, do not even add device parameter to the API call
         """
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = enums.Devices.cpu
-        temp_client.config.indexing_device = "cuda:28"
-
         mock__post = mock.MagicMock()
 
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
@@ -274,7 +270,7 @@ class TestAddDocuments(MarqoTestCase):
         assert run()
 
         args, kwargs = mock__post.call_args
-        assert "device=cuda28" in kwargs["path"]
+        assert "device" not in kwargs["path"]
 
     def test_add_documents_set_refresh(self):
         temp_client = copy.deepcopy(self.client)

--- a/tests/v0_tests/test_bulk_search.py
+++ b/tests/v0_tests/test_bulk_search.py
@@ -263,6 +263,23 @@ class TestBulkSearch(MarqoTestCase):
 
         args, _ = mock__post.call_args_list[0]
         assert "device=cuda2" in args[0]
+    
+    def test_bulk_search_with_no_device(self):
+        """if no device is set, device should not be in path"""
+        temp_client = copy.deepcopy(self.client)
+
+        mock__post = mock.MagicMock()
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            temp_client.bulk_search([{
+                "index": self.index_name_1,
+                "q": "my search term"
+            }])
+            return True
+        assert run()
+
+        args, _ = mock__post.call_args_list[0]
+        assert "device" not in args[0]
 
     def test_prefiltering(self):
         self.client.create_index(index_name=self.index_name_1)

--- a/tests/v0_tests/test_bulk_search.py
+++ b/tests/v0_tests/test_bulk_search.py
@@ -40,7 +40,7 @@ class TestBulkSearch(MarqoTestCase):
     @mock_http_traffic([
         MockHTTPTraffic(
             http_operation="post",
-            path="indexes/bulk/search?device=cpu",
+            path="indexes/bulk/search?&device=cpu",
             content_type='application/json',
             body={
                 "queries": [
@@ -76,13 +76,13 @@ class TestBulkSearch(MarqoTestCase):
             "index": self.index_name_1,
             "q": "title about some doc",
             "context": {"tensor": [{"vector": [1, ] * 3, "weight": 0}, {"vector": [2, ] * 2, "weight": 0}], }
-        }])
+        }], device="cpu")
 
 
     @mock_http_traffic([
         MockHTTPTraffic(
             http_operation="post",
-            path="indexes/bulk/search?device=cpu",
+            path="indexes/bulk/search?&device=cpu",
             content_type='application/json',
             body={
                 "queries": [
@@ -131,7 +131,7 @@ class TestBulkSearch(MarqoTestCase):
                     {"field_name": "add_2", "weight": 1}
                 ]
             }
-        }])
+        }], device="cpu")
 
     @with_documents(lambda self: {self.index_name_1: [{
         "Title": "This is a title about some doc. ",
@@ -247,11 +247,9 @@ class TestBulkSearch(MarqoTestCase):
         assert self.client.index(self.index_name_1).search(
             '"captain"')["hits"][0]["_id"] == "123456"
 
-    def test_search_with_device(self):
+    def test_bulk_search_with_device(self):
         """use default as defined in config unless overridden"""
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = "cpu:4"
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
@@ -259,19 +257,11 @@ class TestBulkSearch(MarqoTestCase):
             temp_client.bulk_search([{
                 "index": self.index_name_1,
                 "q": "my search term"
-            }])
-            temp_client.bulk_search([{
-                "index": self.index_name_1,
-                "q": "my search term"
             }], device="cuda:2")
             return True
         assert run()
 
-        # did we use the defined default device?
         args, _ = mock__post.call_args_list[0]
-        assert "device=cpu4" in args[0]
-        # did we overrride the default device?
-        args, _ = mock__post.call_args_list[1]
         assert "device=cuda2" in args[0]
 
     def test_prefiltering(self):

--- a/tests/v0_tests/test_config.py
+++ b/tests/v0_tests/test_config.py
@@ -12,11 +12,6 @@ class TestConfig(MarqoTestCase):
     def setUp(self) -> None:
         self.endpoint = self.authorized_url
 
-    def test_init_custom_devices(self):
-        c = config.Config(url=self.endpoint,indexing_device="cuda:3", search_device="cuda:4")
-        assert c.indexing_device == "cuda:3"
-        assert c.search_device == "cuda:4"
-
     def test_url_is_s2search(self):
         c = config.Config(url="https://s2search.io/abdcde:8882")
         assert c.cluster_is_s2search

--- a/tests/v0_tests/test_logging.py
+++ b/tests/v0_tests/test_logging.py
@@ -72,15 +72,14 @@ class TestLogging(MarqoTestCase):
             # so no client batching, that means no batch info output,  and therefore only 1 warning
             ({}, {"num_log_msgs": 1, "num_errors_msgs": 1}),
             ({'server_batch_size': 5}, {"num_log_msgs": 1, "num_errors_msgs": 1}),
-            ({'server_batch_size': 5, "processes": 2}, {"num_log_msgs": 1, "num_errors_msgs": 1}),
-            ({"processes": 2}, {"num_log_msgs": 1, "num_errors_msgs": 1}),
+            #({'server_batch_size': 5, "processes": 2}, {"num_log_msgs": 1, "num_errors_msgs": 1}),
+            #({"processes": 2}, {"num_log_msgs": 1, "num_errors_msgs": 1}),
 
             # one error message, one regular info message per client batch
             ({"client_batch_size": 5}, {"num_log_msgs": 6, "num_errors_msgs": 2}),
             ({"client_batch_size": 10, 'server_batch_size': 5}, {"num_log_msgs": 4, "num_errors_msgs": 2}),
-            ({"client_batch_size": 10, 'server_batch_size': 5, "processes": 2},
-             {"num_log_msgs": 4, "num_errors_msgs": 2}),
-            ({"client_batch_size": 10, "processes": 2}, {"num_log_msgs": 4, "num_errors_msgs": 2}),
+            #({"client_batch_size": 10, 'server_batch_size': 5, "processes": 2}, {"num_log_msgs": 4, "num_errors_msgs": 2}),
+            #({"client_batch_size": 10, "processes": 2}, {"num_log_msgs": 4, "num_errors_msgs": 2}),
 
         ]
         for params, expected in params_expected:

--- a/tests/v0_tests/test_logging.py
+++ b/tests/v0_tests/test_logging.py
@@ -61,7 +61,7 @@ class TestLogging(MarqoTestCase):
     def test_add_document_warnings_no_batching(self):
         self._create_img_index(index_name=self.index_name_1)
         with self.assertLogs('marqo', level='INFO') as cm:
-            self.client.index(index_name=self.index_name_1).add_documents(self._get_docs_to_index())
+            self.client.index(index_name=self.index_name_1).add_documents(self._get_docs_to_index(), device="cpu")
             assert len(cm.output) == 1
             assert "errors detected" in cm.output[0].lower()
             assert "info" in cm.output[0].lower()
@@ -87,7 +87,7 @@ class TestLogging(MarqoTestCase):
 
             with self.assertLogs('marqo', level='INFO') as cm:
                 self.client.index(index_name=self.index_name_1).add_documents(
-                    documents=self._get_docs_to_index(), **params)
+                    documents=self._get_docs_to_index(), device="cpu", **params)
                 print(params, expected)
                 assert len(cm.output) == expected['num_log_msgs']
                 error_messages = [msg.lower() for msg in cm.output if "errors detected" in msg.lower()]

--- a/tests/v0_tests/test_parallel.py
+++ b/tests/v0_tests/test_parallel.py
@@ -24,6 +24,8 @@ class TestAddDocumentsPara(MarqoTestCase):
         self.identifiers = [str(uuid.uuid4()) for i in range(100)] 
         self.data = [{'text':f'somethingelse{i}', 'other_text':i[::-1], '_id':i} for i in self.identifiers]
 
+    """
+    NOTE: Removing multi-process functionality soon
 
     def test_add_documents_parallel_no_create_index_get(self) -> None:
 
@@ -91,3 +93,4 @@ class TestAddDocumentsPara(MarqoTestCase):
 
             res = self.client.index(self.index_name_1).search(text_1, search_method='LEXICAL')
             assert res['hits'][0]['text'] == text_1, f"{res}-{text_1}"
+    """

--- a/tests/v0_tests/test_parallel.py
+++ b/tests/v0_tests/test_parallel.py
@@ -24,8 +24,8 @@ class TestAddDocumentsPara(MarqoTestCase):
         self.identifiers = [str(uuid.uuid4()) for i in range(100)] 
         self.data = [{'text':f'somethingelse{i}', 'other_text':i[::-1], '_id':i} for i in self.identifiers]
 
-    """
-    NOTE: Removing multi-process functionality soon
+
+    #NOTE: Removing multi-process functionality soon
 
     def test_add_documents_parallel_no_create_index_get(self) -> None:
 
@@ -93,4 +93,3 @@ class TestAddDocumentsPara(MarqoTestCase):
 
             res = self.client.index(self.index_name_1).search(text_1, search_method='LEXICAL')
             assert res['hits'][0]['text'] == text_1, f"{res}-{text_1}"
-    """

--- a/tests/v0_tests/test_parallel.py
+++ b/tests/v0_tests/test_parallel.py
@@ -19,7 +19,7 @@ class TestAddDocumentsPara(MarqoTestCase):
         except MarqoApiError as s:
             pass
         
-        self.para_params = {'server_batch_size':10, 'processes':2}
+        self.para_params = {'server_batch_size':10, 'processes':2, 'device': "cpu"}
         self.sleep = 1
         self.identifiers = [str(uuid.uuid4()) for i in range(100)] 
         self.data = [{'text':f'somethingelse{i}', 'other_text':i[::-1], '_id':i} for i in self.identifiers]

--- a/tests/v0_tests/test_tensor_search.py
+++ b/tests/v0_tests/test_tensor_search.py
@@ -165,10 +165,8 @@ class TestAddDocuments(MarqoTestCase):
             '"captain"')["hits"][0]["_id"] == "123456"
 
     def test_search_with_device(self):
-        """use default as defined in config unless overridden"""
+        """If device not set, do not add it to path"""
         temp_client = copy.deepcopy(self.client)
-        temp_client.config.search_device = "cpu:4"
-        temp_client.config.indexing_device = enums.Devices.cpu
 
         mock__post = mock.MagicMock()
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
@@ -179,7 +177,7 @@ class TestAddDocuments(MarqoTestCase):
         assert run()
         # did we use the defined default device?
         args, kwargs0 = mock__post.call_args_list[0]
-        assert "device=cpu4" in kwargs0["path"]
+        assert "device" not in kwargs0["path"]
         # did we overrride the default device?
         args, kwargs1 = mock__post.call_args_list[1]
         assert "device=cuda2" in kwargs1["path"]

--- a/tests/v0_tests/test_tensor_search.py
+++ b/tests/v0_tests/test_tensor_search.py
@@ -13,7 +13,7 @@ import time
 from tests.marqo_test import MarqoTestCase
 
 
-class TestAddDocuments(MarqoTestCase):
+class TestSearch(MarqoTestCase):
 
     def setUp(self) -> None:
         self.client = Client(**self.client_settings)
@@ -165,6 +165,18 @@ class TestAddDocuments(MarqoTestCase):
             '"captain"')["hits"][0]["_id"] == "123456"
 
     def test_search_with_device(self):
+        temp_client = copy.deepcopy(self.client)
+        mock__post = mock.MagicMock()
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            temp_client.index(self.index_name_1).search(q="my search term", device="cuda:2")
+            return True
+        assert run()
+        # did we set the device properly?
+        args, kwargs = mock__post.call_args_list[0]
+        assert "device=cuda2" in kwargs["path"]
+    
+    def test_search_with_no_device(self):
         """If device not set, do not add it to path"""
         temp_client = copy.deepcopy(self.client)
 
@@ -172,15 +184,11 @@ class TestAddDocuments(MarqoTestCase):
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
         def run():
             temp_client.index(self.index_name_1).search(q="my search term")
-            temp_client.index(self.index_name_1).search(q="my search term", device="cuda:2")
             return True
         assert run()
         # did we use the defined default device?
         args, kwargs0 = mock__post.call_args_list[0]
         assert "device" not in kwargs0["path"]
-        # did we overrride the default device?
-        args, kwargs1 = mock__post.call_args_list[1]
-        assert "device=cuda2" in kwargs1["path"]
 
     def test_prefiltering(self):
         self.client.create_index(index_name=self.index_name_1)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
Currently, if no device is set when calling add docs, search, or bulk search functions, a default is selected.

* **What is the new behavior (if this is a feature change)?**
- All default devices were removed
- Devices were removed from client config
- When no device is passed in client function, no device parameter is passed to marqo. Marqo itself will do all default calculation. Related PR here: https://github.com/marqo-ai/marqo/pull/508

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. Previously, setting no device would usually default to the client sending `cpu` as device. Now it will send no device.

