### PR TITLE
Disable auto index creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ import marqo
 
 mq = marqo.Client(url='http://localhost:8882')
 
+mq.create_index("my-first-index")
 mq.index("my-first-index").add_documents([
     {
         "Title": "The Travels of Marco Polo",
@@ -276,6 +277,7 @@ import pprint
 
 mq = marqo.Client(url="http://localhost:8882")
 
+mq.create_index("my-weighted-query-index")
 mq.index("my-weighted-query-index").add_documents(
     [
         {

--- a/tests/v0_tests/test_add_documents.py
+++ b/tests/v0_tests/test_add_documents.py
@@ -3,6 +3,8 @@ import functools
 import math
 import pprint
 import random
+
+import pytest
 import requests
 import time
 from marqo.client import Client
@@ -215,17 +217,11 @@ class TestAddDocuments(MarqoTestCase):
         retrieved = self.client.index(self.index_name_1).get_document(document_id='123')
         assert retrieved == my_doc
 
-    def test_add_documents_implicitly_create_index(self):
-        try:
-            self.client.index(self.index_name_1).search("some str")
-            raise AssertionError
-        except MarqoWebError as s:
-            assert "index_not_found" == s.code
-        self.client.create_index(self.index_name_1)
-        self.client.index(self.index_name_1).add_documents([{"abd": "efg"}])
-        # it works:
-        self.client.index(self.index_name_1).search("some str")
+    def test_add_documents_missing_index_fails(self):
+        with pytest.raises(MarqoWebError) as ex:
+            self.client.index(self.index_name_1).add_documents([{"abd": "efg"}])
 
+        assert "index_not_found" == ex.value.code
     def test_add_documents_with_device(self):
         temp_client = copy.deepcopy(self.client)
 

--- a/tests/v0_tests/test_add_documents.py
+++ b/tests/v0_tests/test_add_documents.py
@@ -147,6 +147,7 @@ class TestAddDocuments(MarqoTestCase):
             self.client.delete_index(self.index_name_1)
         except MarqoApiError:
             pass
+        self.client.create_index(self.index_name_1)
         ix = self.client.index(index_name=self.index_name_1)
         doc_ids = [str(num) for num in range(0, 100)]
 
@@ -220,6 +221,7 @@ class TestAddDocuments(MarqoTestCase):
             raise AssertionError
         except MarqoWebError as s:
             assert "index_not_found" == s.code
+        self.client.create_index(self.index_name_1)
         self.client.index(self.index_name_1).add_documents([{"abd": "efg"}])
         # it works:
         self.client.index(self.index_name_1).search("some str")
@@ -325,6 +327,7 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_update_documents(self):
         original_doc = {"d1": "blah", "_id": "1234"}
+        self.client.create_index(self.index_name_1)
         self.client.index(self.index_name_1).add_documents(documents=[original_doc])
         assert original_doc == self.client.index(self.index_name_1).get_document(document_id='1234')
         new_doc = {"_id": "brand_new", "Content": "fascinating"}
@@ -478,6 +481,7 @@ class TestAddDocuments(MarqoTestCase):
 
     def test_add_lists_non_tensor(self):
         original_doc = {"d1": "blah", "_id": "1234", 'my list': ['tag-1', 'tag-2']}
+        self.client.create_index(self.index_name_1)
         self.client.index(self.index_name_1).add_documents(documents=[original_doc], non_tensor_fields=['my list'])
 
         if self.IS_MULTI_INSTANCE:
@@ -501,6 +505,7 @@ class TestAddDocuments(MarqoTestCase):
         assert len(bad_res['hits']) == 0
 
     def test_use_existing_fields(self):
+        self.client.create_index(self.index_name_1)
         self.client.index(index_name=self.index_name_1).add_documents(
             documents=[
                 {

--- a/tests/v0_tests/test_demos.py
+++ b/tests/v0_tests/test_demos.py
@@ -20,6 +20,7 @@ class TestDemo(MarqoTestCase):
 
     def test_demo(self):
         client = Client(**self.client_settings)
+        client.create_index("cool-index-1")
         client.index("cool-index-1").add_documents([
             {
                 "Title": "The Legend of the River",
@@ -58,6 +59,7 @@ class TestDemo(MarqoTestCase):
 
         mq = marqo.Client(**self.client_settings)
 
+        mq.create_index("my-first-index")
         mq.index("my-first-index").add_documents([
             {
                 "Title": "The Travels of Marco Polo",
@@ -117,6 +119,7 @@ class TestDemo(MarqoTestCase):
     def test_readme_example_weighted_query(self):
         import marqo
         mq = marqo.Client(**self.client_settings)
+        mq.create_index("my-weighted-query-index")
         mq.index("my-weighted-query-index").add_documents([
             {
                 "Title": "Smartphone",

--- a/tests/v0_tests/test_parallel.py
+++ b/tests/v0_tests/test_parallel.py
@@ -18,7 +18,9 @@ class TestAddDocumentsPara(MarqoTestCase):
             self.client.delete_index(self.index_name_1)
         except MarqoApiError as s:
             pass
-        
+
+        self.client.create_index(self.index_name_1)
+
         self.para_params = {'server_batch_size':10, 'processes':2, 'device': "cpu"}
         self.sleep = 1
         self.identifiers = [str(uuid.uuid4()) for i in range(100)] 
@@ -27,13 +29,7 @@ class TestAddDocumentsPara(MarqoTestCase):
 
     #NOTE: Removing multi-process functionality soon
 
-    def test_add_documents_parallel_no_create_index_get(self) -> None:
-
-        try:
-            self.client.delete_index(self.index_name_1)
-        except MarqoApiError as s:
-            pass
-
+    def test_add_documents_parallel_get(self) -> None:
         identifiers = self.identifiers
         data = self.data
 
@@ -46,13 +42,7 @@ class TestAddDocumentsPara(MarqoTestCase):
             res = self.client.index(self.index_name_1).get_document(_id)
             assert res == data[identifiers.index(_id)]
 
-    def test_add_documents_parallel_no_create_index_search_single_field(self) -> None:
-
-        try:
-            self.client.delete_index(self.index_name_1)
-        except MarqoApiError as s:
-            pass
-
+    def test_add_documents_parallel_search_single_field(self) -> None:
         identifiers = self.identifiers
         data = self.data
 
@@ -69,13 +59,7 @@ class TestAddDocumentsPara(MarqoTestCase):
             res = self.client.index(self.index_name_1).search(text_1, search_method='LEXICAL', searchable_attributes=['text', 'other_text'])
             assert res['hits'][0]['text'] == text_1, f"{res}-{text_1}"
 
-    def test_add_documents_parallel_no_create_index_search(self) -> None:
-
-        try:
-            self.client.delete_index(self.index_name_1)
-        except MarqoApiError as s:
-            pass
-
+    def test_add_documents_parallel_search(self) -> None:
         identifiers = self.identifiers
         data = self.data
 

--- a/tests/v0_tests/test_tensor_search.py
+++ b/tests/v0_tests/test_tensor_search.py
@@ -354,6 +354,7 @@ class TestSearch(MarqoTestCase):
             "dont#tensorise Me": "Dog",
             "tensorise_me": "quarterly earnings report"
         }]
+        self.client.create_index(index_name=self.index_name_1)
         self.client.index(index_name=self.index_name_1).add_documents(
             docs, auto_refresh=True, non_tensor_fields=["dont#tensorise Me"]
         )
@@ -380,7 +381,8 @@ class TestSearch(MarqoTestCase):
                 filter_field: "Alpaca"
             }
             ]
-            add_res = self.client.index(index_name=self.index_name_1).add_documents(
+            self.client.create_index(self.index_name_1)
+            self.client.index(index_name=self.index_name_1).add_documents(
                 docs, auto_refresh=True, non_tensor_fields=[field_to_not_search]
             )
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
When adding documents to an index that does not exist, Marqo automatically and silently creates an index with a default index configuration.

* **What is the new behavior (if this is a feature change)?**
Attempting to add documents to an index that does not exist will fail with an error. Indices must be created explicitly before adding documents. 
See https://github.com/marqo-ai/marqo/pull/516

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. Users must ensure an index exists before documents are added, or must handle the error. Code that relies on the removed automatic index creation behaviour will fail.

* **Other information**:

