### PR TITLE
Align `get_indexes()` with API spec

### DIFF
--- a/src/marqo/client.py
+++ b/src/marqo/client.py
@@ -121,18 +121,15 @@ class Client:
             return Index(self.config, index_name=index_name)
         raise Exception('The index UID should not be None')
 
-    def get_indexes(self) -> Dict[str, List[Index]]:
+    def get_indexes(self) -> Dict[str, List[Dict[str, str]]]:
         """Get all indexes.
 
         Returns:
-        Indexes, a dictionary with the name of indexes.
+            Indexes, a dictionary with the name of indexes.
         """
         response = self.http.get(path='indexes')
         response['results'] = [
-            Index(
-                config=self.config,
-                index_name=index_info["index_name"],
-            )
+            {'index_name': index_info["index_name"]}
             for index_info in response["results"]
         ]
         return response

--- a/tests/v0_tests/test_get_indexes.py
+++ b/tests/v0_tests/test_get_indexes.py
@@ -1,11 +1,8 @@
-import pprint
-import time
-import marqo.index
 from marqo.client import Client
-from marqo.errors import MarqoApiError, MarqoError, MarqoWebError
-import unittest
+from marqo.errors import MarqoApiError
 from tests.marqo_test import MarqoTestCase
-
+import time
+from typing import Dict, List
 
 class TestAddDocuments(MarqoTestCase):
 
@@ -27,9 +24,9 @@ class TestAddDocuments(MarqoTestCase):
             except MarqoApiError:
                 pass
 
-    def _is_index_name_in_get_indexes_response(self, index_name, get_indexes_response):
+    def _is_index_name_in_get_indexes_response(self, index_name: str, get_indexes_response: Dict[str, List[Dict[str, str]]]):
         for found_index in get_indexes_response['results']:
-            if index_name == found_index.index_name:
+            if index_name == found_index["index_name"]:
                 return True
         return False
 
@@ -53,31 +50,4 @@ class TestAddDocuments(MarqoTestCase):
         assert len(ix_1['results']) > len(ix_0['results'])
 
         for found_index in ix_2['results']:
-            assert isinstance(found_index, marqo.index.Index)
-
-    def test_get_indexes_usable(self):
-        """Are the indices we get back usable? """
-        self.client.create_index(self.index_name_1)
-        get_ixes_res = self.client.get_indexes()
-        assert self._is_index_name_in_get_indexes_response(self.index_name_1, get_ixes_res)
-
-        my_ix = None
-        for found_index in get_ixes_res['results']:
-            if self.index_name_1 == found_index.index_name:
-                my_ix = found_index
-
-        if my_ix is None:
-            raise AssertionError
-
-        assert my_ix.get_stats()['numberOfDocuments'] == 0
-        my_ix.add_documents([{'some doc': 'gold fish'}])
-
-        if self.IS_MULTI_INSTANCE:
-            time.sleep(1)
-
-        assert my_ix.get_stats()['numberOfDocuments'] == 1
-
-        if self.IS_MULTI_INSTANCE:
-            self.warm_request(my_ix.search,q='aquatic animal')
-
-        assert len(my_ix.search(q='aquatic animal')['hits']) == 1
+            assert isinstance(found_index, dict)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
-[tox]
-envlist = py38
+; [tox]
+; envlist = py38
 
 [testenv]
 passenv = 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Currently get_indexes returns a dictionary of str and list of Index objects. The docstring and the REST API however return a dictionary of str and a list of dicts of str and str.

e.g. the python client returns
```
{'results': [<marqo.index.Index object at 0x103f65090>]}
```
Where the REST API returns
```
{'results': [{"index-name", "my-first-index"}]}
```

* **What is the new behavior (if this is a feature change)?**
The new behaviour is to have `get_indexes()` return the same structure as the REST API
```
>>> mq.get_indexes()
{'results': [{"index-name", "my-first-index"}]}
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This PR does break the use case where users use the `Index` objects returned from `get_indexes()`.

e.g.
```
>>> indexes = mq.get_indexes()['results']
>>> for index in indexes:
...    print(index.get_stats())
>>>
```

However this usage pattern is never documented anywhere or used in any examples as far as I can see. It only appears in one of the tests for the `get_indexes()` method.

* **Other information**:
This changes means that you can print the results as dictionaries have `__repr__`.

An alternative would be to add `__getitem__` and `__repr__` to the index object to retain both the existing functionality and let users treat it like a dict. e.g.
```
>>> indexes = mq.get_indexes()['results']
>>> for index in indexes:
...    print(index.get_stats())
>>> print(indexes)
[Index(config=<marqo.config.Config object at 0x10382f610>, http=<marqo._httprequests.HttpRequests object at 0x102682b10>, index_name='my-first-index', created_at=None, updated_at=None)]
>>> indexes[0]['index_name']
'my-first-index'
```
