### PR TITLE
Gracefully handling timeout error in api/indexes endpoint

### DIFF
--- a/src/marqo/client.py
+++ b/src/marqo/client.py
@@ -11,7 +11,8 @@ from marqo import utils, enums
 from marqo import errors
 from marqo.version import minimum_supported_marqo_version
 from marqo.marqo_logging import mq_logger
-from packaging import version
+# we want to avoid name conflicts with marqo.version
+from packaging import version as versioning_helpers
 
 # A dictionary to cache the marqo url and version for compatibility check
 marqo_url_and_version_cache = {}
@@ -201,7 +202,7 @@ class Client:
         if self.url not in marqo_url_and_version_cache:
             marqo_url_and_version_cache[self.url] = self.get_marqo()["version"]
         marqo_version = marqo_url_and_version_cache[self.url]
-        if version.parse(marqo_version) < version(minimum_supported_marqo_version()):
+        if versioning_helpers.parse(marqo_version) < versioning_helpers.parse(minimum_supported_marqo_version()):
             mq_logger.warning(f"Your Marqo Python client requires a minimum Marqo version of "
                               f"{minimum_supported_marqo_version()} to function properly, while your Marqo version is {marqo_version}. "
                               f"Please upgrade your Marqo instance to avoid potential errors. "

--- a/src/marqo/errors.py
+++ b/src/marqo/errors.py
@@ -166,6 +166,8 @@ class BackendTimeoutError(InternalError):
         self.message = f"Timeout error communicating with Marqo: {message}"
 
 
+# NON HTTP ERRORS:
+
 class MarqoCloudIndexNotReadyError(MarqoError):
     """Error when Marqo index is not ready"""
     code = "index_not_ready_cloud"

--- a/src/marqo/marqo_url_resolver.py
+++ b/src/marqo/marqo_url_resolver.py
@@ -1,8 +1,11 @@
-import logging
 import time
+from marqo.marqo_logging import mq_logger
 import requests
-
-from marqo.errors import MarqoCloudIndexNotFoundError, MarqoCloudIndexNotReadyError
+from requests.exceptions import Timeout
+from marqo.errors import (
+    MarqoCloudIndexNotFoundError,
+    MarqoCloudIndexNotReadyError,
+)
 
 
 class MarqoUrlResolver:
@@ -30,10 +33,19 @@ class MarqoUrlResolver:
         raise MarqoCloudIndexNotFoundError(item)
 
     def _refresh_urls(self, timeout=None):
-        response = requests.get('https://api.marqo.ai/api/indexes',
-                                headers={"x-api-key": self.api_key}, timeout=timeout)
+        try:
+            response = requests.get('https://api.marqo.ai/api/indexes',
+                                    headers={"x-api-key": self.api_key}, timeout=timeout)
+        except Timeout:
+            mq_logger.warning(
+                f"Timeout getting and caching URLs for Marqo Cloud indexes from the"
+                f" /api/indexes/ endpoint. Please contact marqo support at support@marqo.ai if this message"
+                f" persists."
+            )
+            return None
+
         if not response.ok:
-            logging.warning(response.text)
+            mq_logger.warning(response.text)
         response_json = response.json()
         for index in response_json['indices']:
             if index.get('index_status') in ["READY", "CREATING"]:

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -7,7 +7,7 @@ __minimum_supported_marqo_version__ = "0.1.0"
 def supported_marqo_version() -> str:
     return f"This Marqo Python client is built for Marqo release ({__marqo_version__}) \n" \
            f"{__marqo_release_page__} \n" \
-           f"The minimum supported Marqo version is ({__minimum_supported_marqo_version__}) \n"
+           f"The minimum supported Marqo version for this client is ({__minimum_supported_marqo_version__}) \n"
 
 
 def minimum_supported_marqo_version() -> str:


### PR DESCRIPTION
- handling timeout error from control plane
- fixed bug in minimum supported version check

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix 

* **What is the current behavior?** (You can also link to an open issue here)
No graceful handling of timeout from `api/indexes/` endpoint. Bug in Marqo minimum version check.

* **What is the new behavior (if this is a feature change)?**
Graceful handling of timeout from `api/indexes/` endpoint - timeouts get excepted and logged.  Fixed Bug in Marqo minimum version check.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

**Testing**
Tox tests pass against mainline

<img width="1344" alt="image" src="https://github.com/marqo-ai/py-<img width="1348" alt="image" src="https://github.com/marqo-ai/py-marqo/assets/107458762/6023adbd-17ea-4f09-acb4-c5de05983f5e">

