### PR TITLE
replace load_balancer_dns_name with endpoint

### DIFF
--- a/src/marqo/marqo_url_resolver.py
+++ b/src/marqo/marqo_url_resolver.py
@@ -49,6 +49,6 @@ class MarqoUrlResolver:
         response_json = response.json()
         for index in response_json['indices']:
             if index.get('index_status') in ["READY", "CREATING"]:
-                self._urls_mapping[index['index_status']][index['index_name']] = index.get('load_balancer_dns_name')
+                self._urls_mapping[index['index_status']][index['index_name']] = index.get('endpoint')
         if self._urls_mapping:
             self.timestamp = time.time()

--- a/tests/v0_tests/test_marqo_url_resolver.py
+++ b/tests/v0_tests/test_marqo_url_resolver.py
@@ -9,8 +9,8 @@ class TestMarqoUrlResolver(MarqoTestCase):
     @patch("requests.get")
     def test_refresh_urls_if_needed(self, mock_get):
         mock_get.return_value.json.return_value = {"indices": [
-            {"index_name": "index1", "load_balancer_dns_name": "example.com", "index_status": "READY"},
-            {"index_name": "index2", "load_balancer_dns_name": "example2.com", "index_status": "READY"}
+            {"index_name": "index1", "endpoint": "example.com", "index_status": "READY"},
+            {"index_name": "index2", "endpoint": "example2.com", "index_status": "READY"}
         ]}
         resolver = MarqoUrlResolver(api_key="your-api-key", expiration_time=60)
         initial_timestamp = resolver.timestamp
@@ -33,8 +33,8 @@ class TestMarqoUrlResolver(MarqoTestCase):
     @patch("requests.get")
     def test_refresh_urls_if_not_needed(self, mock_get):
         mock_get.return_value.json.return_value = {"indices": [
-            {"index_name": "index1", "load_balancer_dns_name": "example.com", "index_status": "READY"},
-            {"index_name": "index2", "load_balancer_dns_name": "example2.com", "index_status": "READY"}
+            {"index_name": "index1", "endpoint": "example.com", "index_status": "READY"},
+            {"index_name": "index2", "endpoint": "example2.com", "index_status": "READY"}
         ]}
         resolver = MarqoUrlResolver(api_key="your-api-key", expiration_time=60)
 
@@ -56,8 +56,8 @@ class TestMarqoUrlResolver(MarqoTestCase):
     @patch("requests.get")
     def test_refresh_includes_only_ready(self, mock_get):
         mock_get.return_value.json.return_value = {"indices": [
-            {"index_name": "index1", "load_balancer_dns_name": "example.com", "index_status": "READY"},
-            {"index_name": "index2", "load_balancer_dns_name": "example2.com", "index_status": "NOT READY"}
+            {"index_name": "index1", "endpoint": "example.com", "index_status": "READY"},
+            {"index_name": "index2", "endpoint": "example2.com", "index_status": "NOT READY"}
         ]}
         resolver = MarqoUrlResolver(api_key="your-api-key", expiration_time=60)
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* When index is resolved by marqo-url-resolver it will retrieve url from "endpoint" field instead of "load_balancer_dns_name"


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:

