### PR TITLE
Add tensor_fields parameter to add_documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,17 +107,19 @@ import marqo
 mq = marqo.Client(url='http://localhost:8882')
 
 mq.create_index("my-first-index")
-mq.index("my-first-index").add_documents([
-    {
-        "Title": "The Travels of Marco Polo",
-        "Description": "A 13th-century travelogue describing Polo's travels"
-    }, 
-    {
-        "Title": "Extravehicular Mobility Unit (EMU)",
-        "Description": "The EMU is a spacesuit that provides environmental protection, "
-                       "mobility, life support, and communications for astronauts",
-        "_id": "article_591"
-    }]
+mq.index("my-first-index").add_documents(
+    [
+        {
+            "Title": "The Travels of Marco Polo",
+            "Description": "A 13th-century travelogue describing Polo's travels"},
+        {
+            "Title": "Extravehicular Mobility Unit (EMU)",
+            "Description": "The EMU is a spacesuit that provides environmental protection, "
+                           "mobility, life support, and communications for astronauts",
+            "_id": "article_591"
+        }
+    ], 
+    tensor_fields=["Title", "Description"]
 )
 
 results = mq.index("my-first-index").search(
@@ -278,8 +280,7 @@ import pprint
 mq = marqo.Client(url="http://localhost:8882")
 
 mq.create_index("my-weighted-query-index")
-mq.index("my-weighted-query-index").add_documents(
-    [
+mq.index("my-weighted-query-index").add_documents([
         {
             "Title": "Smartphone",
             "Description": "A smartphone is a portable computer device that combines mobile telephone "
@@ -296,7 +297,8 @@ mq.index("my-weighted-query-index").add_documents(
             "is an extinct carnivorous marsupial."
             "The last known of its species died in 1936.",
         },
-    ]
+    ],
+    tensor_fields=["Title", "Description"]
 )
 
 # initially we ask for a type of communications device which is popular in the 21st century
@@ -371,9 +373,6 @@ mq.index("my-first-multimodal-index").add_documents(
             },
         },
     ],
-    # Create the mappings, here we define our captioned_image mapping 
-    # which weights the image more heavily than the caption - these pairs 
-    # will be represented by a single vector in the index
     mappings={
         "captioned_image": {
             "type": "multimodal_combination",
@@ -383,6 +382,7 @@ mq.index("my-first-multimodal-index").add_documents(
             },
         }
     },
+    tensor_fields=["captioned_image"],
 )
 
 # Search this index with a simple text query

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -176,8 +176,8 @@ class Index:
 
         start_time_client_request = timer()
         if highlights is not None:
-            logging.warning("Deprecation warning for parameter 'highlights'. "
-                            "Please use the 'showHighlights' instead. ")
+            mq_logger.warning("Deprecation warning for parameter 'highlights'. "
+                              "Please use the 'showHighlights' instead. ")
             show_highlights = highlights if show_highlights is True else show_highlights
 
         path_with_query_str = (
@@ -311,8 +311,8 @@ class Index:
                                          'Use `tensor_fields=[]` to index for lexical-only search.')
 
         if non_tensor_fields is not None:
-            logging.warning('The `non_tensor_fields` parameter has been deprecated and will be removed in Marqo 2.0.0. '
-                            'Use `tensor_fields` instead.')
+            mq_logger.warning('The `non_tensor_fields` parameter has been deprecated and will be removed in '
+                              'Marqo 2.0.0. Use `tensor_fields` instead.')
 
         if image_download_headers is None:
             image_download_headers = dict()

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -308,7 +308,7 @@ class Index:
 
         if tensor_fields is None and non_tensor_fields is None:
             raise errors.InvalidArgError('You must include the `tensor_fields` parameter. '
-                                         'Use tensorFields=[] to index for lexical-only search.')
+                                         'Use `tensor_fields=[]` to index for lexical-only search.')
 
         if non_tensor_fields is not None:
             logging.warning('The `non_tensor_fields` parameter has been deprecated and will be removed in Marqo 2.0.0. '
@@ -360,7 +360,7 @@ class Index:
             "mappings" : mappings,
             "modelAuth": model_auth,
         }
-        if tensor_fields:
+        if tensor_fields is not None:
             base_body['tensorFields'] = tensor_fields
         else:
             base_body['nonTensorFields'] = non_tensor_fields

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__marqo_version__ = "0.1.0"
+__marqo_version__ = "1.0.0"
 __marqo_release_page__ = f"https://github.com/marqo-ai/marqo/releases/tag/{__marqo_version__}"
 
 __minimum_supported_marqo_version__ = "0.1.0"

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -90,7 +90,7 @@ def with_documents(index_to_documents_fn: Callable[[], Dict[str, List[Dict[str, 
                 if len(docs) == 0:
                     continue
                 self.client.create_index(index_name=index_name)
-                self.client.index(index_name).add_documents(docs)
+                self.client.index(index_name).add_documents(docs, non_tensor_fields=[])
                 if self.IS_MULTI_INSTANCE:
                     self.warm_request(self.client.bulk_search, [{
                         "index": index_name,

--- a/tests/v0_tests/test_add_documents.py
+++ b/tests/v0_tests/test_add_documents.py
@@ -544,4 +544,12 @@ class TestAddDocuments(MarqoTestCase):
 
         assert run()
 
+    def test_add_docs_logs_deprecation_warning_if_non_tensor_fields(self):
+        # Arrange
+        documents = [{'id': 'doc1', 'text': 'Test document'}]
+        non_tensor_fields = ['text']
 
+        with self.assertLogs('marqo', level='WARNING') as cm:
+            self.client.create_index(self.index_name_1)
+            self.client.index(self.index_name_1).add_documents(documents=documents, non_tensor_fields=non_tensor_fields)
+            self.assertTrue({'`non_tensor_fields`', 'Marqo', '2.0.0.'}.issubset(set(cm.output[0].split(" "))))

--- a/tests/v0_tests/test_boost_search.py
+++ b/tests/v0_tests/test_boost_search.py
@@ -32,7 +32,8 @@ class TestBoostSearch(MarqoTestCase):
                     "Description": "A history of household pets",
                     "_id": "d2"
                 }
-            ]
+            ],
+            tensor_fields=["Title", "Description"]
         )
 
         self.query = "What are the best pets"

--- a/tests/v0_tests/test_bulk_search.py
+++ b/tests/v0_tests/test_bulk_search.py
@@ -176,7 +176,7 @@ class TestBulkSearch(MarqoTestCase):
     def test_search_highlights(self):
         """Tests if show_highlights works and if the deprecation behaviour is expected"""
         self.client.create_index(index_name=self.index_name_1)
-        self.client.index(index_name=self.index_name_1).add_documents([{"f1": "some doc"}])
+        self.client.index(index_name=self.index_name_1).add_documents([{"f1": "some doc"}], tensor_fields=["f1"])
         for params, expected_highlights_presence in [
                 ({}, True),
                 ({"showHighlights": False}, False),
@@ -298,7 +298,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ],auto_refresh=True)
+        ], auto_refresh=True, tensor_fields=["doc title", "field X", "abc-123", "field1", "an_int"])
 
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.bulk_search, [{
@@ -336,7 +336,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         x = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], auto_refresh=True)
+        ], auto_refresh=True, tensor_fields=["doc title", "field X", "abc-123", "field1", "an_int"])
         atts = ["doc title", "an_int"]
         for search_method in [enums.SearchMethods.TENSOR,
                               enums.SearchMethods.LEXICAL]:
@@ -376,7 +376,7 @@ class TestBulkSearch(MarqoTestCase):
                         for i in range(num_docs)]
         
         self.client.index(index_name=self.index_name_1).add_documents(
-            docs, auto_refresh=False, client_batch_size=50
+            docs, auto_refresh=False, client_batch_size=50, tensor_fields=["Title"]
         )
         self.client.index(index_name=self.index_name_1).refresh()
 
@@ -432,7 +432,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         self.client.create_index(index_name=self.index_name_1, settings_dict=image_index_config)
         self.client.index(index_name=self.index_name_1).add_documents(
-            documents=docs, auto_refresh=True
+            documents=docs, auto_refresh=True, tensor_fields=["loc a", "loc b"]
         )
         queries_expected_ordering = [
             ({"Nature photography": 2.0, "Artefact": -2}, ['realistic_hippo', 'artefact_hippo']),
@@ -475,7 +475,7 @@ class TestBulkSearch(MarqoTestCase):
         }
         x = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], auto_refresh=True)
+        ], auto_refresh=True, tensor_fields=["doc title", "abc-123", "field X", "field1"])
 
         score_modifiers = {
             "multiply_score_by":[{"field_name": "multiply", "weight": 1}],

--- a/tests/v0_tests/test_custom_vector_search.py
+++ b/tests/v0_tests/test_custom_vector_search.py
@@ -27,7 +27,7 @@ class TestCustomVectorSearch(MarqoTestCase):
                     "Description": "A history of household pets",
                     "_id": "d2"
                 }
-            ]
+            ], tensor_fields=["Title", "Description"]
         )
         self.vector_dim = 512
 

--- a/tests/v0_tests/test_demos.py
+++ b/tests/v0_tests/test_demos.py
@@ -38,7 +38,7 @@ class TestDemo(MarqoTestCase):
                 S2Search is based in Melbourne. Melbourne has beautiful waterways running through it.
                 """
             },
-        ])
+        ], tensor_fields=["Title", "Description", "Key Points"])
         print("\nSearching the phrase 'River' across all fields")
         
         if self.IS_MULTI_INSTANCE:
@@ -60,17 +60,20 @@ class TestDemo(MarqoTestCase):
         mq = marqo.Client(**self.client_settings)
 
         mq.create_index("my-first-index")
-        mq.index("my-first-index").add_documents([
-            {
-                "Title": "The Travels of Marco Polo",
-                "Description": "A 13th-century travelogue describing Polo's travels"},
-            {
-                "Title": "Extravehicular Mobility Unit (EMU)",
-                "Description": "The EMU is a spacesuit that provides environmental protection, "
-                               "mobility, life support, and communications for astronauts",
-                "_id": "article_591"
-            }
-        ])
+        mq.index("my-first-index").add_documents(
+            [
+                {
+                    "Title": "The Travels of Marco Polo",
+                    "Description": "A 13th-century travelogue describing Polo's travels"},
+                {
+                    "Title": "Extravehicular Mobility Unit (EMU)",
+                    "Description": "The EMU is a spacesuit that provides environmental protection, "
+                                   "mobility, life support, and communications for astronauts",
+                    "_id": "article_591"
+                }
+            ],
+            tensor_fields=["Title", "Description"]
+        )
 
         if self.IS_MULTI_INSTANCE:
             self.warm_request(mq.index("my-first-index").search,
@@ -121,23 +124,25 @@ class TestDemo(MarqoTestCase):
         mq = marqo.Client(**self.client_settings)
         mq.create_index("my-weighted-query-index")
         mq.index("my-weighted-query-index").add_documents([
-            {
-                "Title": "Smartphone",
-                "Description": "A smartphone is a portable computer device that combines mobile telephone "
-                "functions and computing functions into one unit.",
-            },
-            {
-                "Title": "Telephone",
-                "Description": "A telephone is a telecommunications device that permits two or more users to"
-                "conduct a conversation when they are too far apart to be easily heard directly.",
-            },
-            {
-                "Title": "Thylacine",
-                "Description": "The thylacine, also commonly known as the Tasmanian tiger or Tasmanian wolf, "
-                "is an extinct carnivorous marsupial."
-                "The last known of its species died in 1936.",
-            },
-        ])
+                {
+                    "Title": "Smartphone",
+                    "Description": "A smartphone is a portable computer device that combines mobile telephone "
+                    "functions and computing functions into one unit.",
+                },
+                {
+                    "Title": "Telephone",
+                    "Description": "A telephone is a telecommunications device that permits two or more users to"
+                    "conduct a conversation when they are too far apart to be easily heard directly.",
+                },
+                {
+                    "Title": "Thylacine",
+                    "Description": "The thylacine, also commonly known as the Tasmanian tiger or Tasmanian wolf, "
+                    "is an extinct carnivorous marsupial."
+                    "The last known of its species died in 1936.",
+                },
+            ],
+            tensor_fields=["Title", "Description"]
+        )
 
         r1 = mq.index("my-weighted-query-index").get_stats()
         assert r1["numberOfDocuments"] == 3
@@ -227,6 +232,7 @@ class TestDemo(MarqoTestCase):
                     },
                 }
             },
+            tensor_fields=["captioned_image"],
         )
 
         r1 = mq.index("my-first-multimodal-index").get_stats()

--- a/tests/v0_tests/test_get_indexes.py
+++ b/tests/v0_tests/test_get_indexes.py
@@ -70,7 +70,7 @@ class TestAddDocuments(MarqoTestCase):
             raise AssertionError
 
         assert my_ix.get_stats()['numberOfDocuments'] == 0
-        my_ix.add_documents([{'some doc': 'gold fish'}])
+        my_ix.add_documents([{'some doc': 'gold fish'}], tensor_fields=['some doc'])
 
         if self.IS_MULTI_INSTANCE:
             time.sleep(1)

--- a/tests/v0_tests/test_image_chunking.py
+++ b/tests/v0_tests/test_image_chunking.py
@@ -49,7 +49,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (aking to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], tensor_fields=['location', 'description', 'attributes'])
 
         # test the search works
         if self.IS_MULTI_INSTANCE:
@@ -98,7 +98,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], tensor_fields=['location', 'description', 'attributes'])
 
         # test the search works
         if self.IS_MULTI_INSTANCE:

--- a/tests/v0_tests/test_index.py
+++ b/tests/v0_tests/test_index.py
@@ -68,7 +68,7 @@ class TestIndex(MarqoTestCase):
         }
         self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ])
+        ], tensor_fields=["Blurb", "Title"])
         res = self.client.index(self.index_name_1).get_documents(
             ["article_152", "article_490", "article_985"]
         )
@@ -99,7 +99,7 @@ class TestIndex(MarqoTestCase):
         }
         self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ])
+        ], tensor_fields=["Blurb", "Title"])
         res = self.client.index(self.index_name_1).get_documents(
             ["article_152", "article_490", "article_985"],
             expose_facets=True
@@ -128,7 +128,7 @@ class TestIndex(MarqoTestCase):
         }
         self.client.index(self.index_name_1).add_documents([
             d1
-        ])
+        ], tensor_fields=["Blurb", "Title"])
         doc_res = self.client.index(self.index_name_1).get_document(
             document_id="article_152",
             expose_facets=True

--- a/tests/v0_tests/test_logging.py
+++ b/tests/v0_tests/test_logging.py
@@ -61,7 +61,8 @@ class TestLogging(MarqoTestCase):
     def test_add_document_warnings_no_batching(self):
         self._create_img_index(index_name=self.index_name_1)
         with self.assertLogs('marqo', level='INFO') as cm:
-            self.client.index(index_name=self.index_name_1).add_documents(self._get_docs_to_index(), device="cpu")
+            self.client.index(index_name=self.index_name_1).add_documents(self._get_docs_to_index(), device="cpu",
+                                                                          tensor_fields=["Title"])
             assert len(cm.output) == 1
             assert "errors detected" in cm.output[0].lower()
             assert "info" in cm.output[0].lower()
@@ -79,7 +80,7 @@ class TestLogging(MarqoTestCase):
 
             with self.assertLogs('marqo', level='INFO') as cm:
                 self.client.index(index_name=self.index_name_1).add_documents(
-                    documents=self._get_docs_to_index(), device="cpu", **params)
+                    documents=self._get_docs_to_index(), device="cpu", **params, tensor_fields=["Title"])
                 print(params, expected)
                 assert len(cm.output) == expected['num_log_msgs']
                 error_messages = [msg.lower() for msg in cm.output if "errors detected" in msg.lower()]

--- a/tests/v0_tests/test_model_auth.py
+++ b/tests/v0_tests/test_model_auth.py
@@ -24,7 +24,7 @@ class TestAddDocumentsModelAuth(MarqoTestCase):
             mock_s3_model_auth = {'s3': {'aws_access_key_id': 'some_acc_key',
                                          'aws_secret_access_key': 'some_sec_acc_key'}}
             self.client.index(index_name=self.index_name_1).add_documents(
-                documents=[{"some": "data"}], model_auth=mock_s3_model_auth)
+                documents=[{"some": "data"}], model_auth=mock_s3_model_auth, tensor_fields=["some"])
             args, kwargs = mock__post.call_args
             assert "modelAuth" in kwargs['body']
             assert kwargs['body']['modelAuth'] == mock_s3_model_auth
@@ -43,7 +43,7 @@ class TestAddDocumentsModelAuth(MarqoTestCase):
             expected_str = f"&model_auth={convert_dict_to_url_params(mock_s3_model_auth)}"
             self.client.index(index_name=self.index_name_1).add_documents(
                 documents=[{"some": f"data {i}"} for i in range(20)], model_auth=mock_s3_model_auth,
-                client_batch_size=10
+                client_batch_size=10, tensor_fields=["some"]
             )
             for call in mock__post.call_args_list:
                 _, kwargs = call

--- a/tests/v0_tests/test_model_cache_management.py
+++ b/tests/v0_tests/test_model_cache_management.py
@@ -80,7 +80,7 @@ class TestModelCacheManagement(MarqoTestCase):
             "doc title": "Cool Document 1",
             "field 1": "some extra info"
         }
-        self.client.index(self.index_name).add_documents([d1], device="cpu")
+        self.client.index(self.index_name).add_documents([d1], device="cpu", tensor_fields=["doc title", "field 1"])
         res = self.client.eject_model(self.MODEL, "cpu")
         assert res["result"] == "success"
         assert res["message"].startswith("successfully eject")

--- a/tests/v0_tests/test_sentence_chunking.py
+++ b/tests/v0_tests/test_sentence_chunking.py
@@ -47,7 +47,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], tensor_fields=['attributes', 'description', 'misc'])
 
         # test the search works
         if self.IS_MULTI_INSTANCE:
@@ -83,7 +83,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], tensor_fields=['attributes', 'description', 'misc'])
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'
@@ -147,7 +147,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(self.index_name).add_documents([document1])
+        client.index(self.index_name).add_documents([document1], tensor_fields=['attributes', 'description', 'misc'])
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'

--- a/tests/v0_tests/test_telemetry.py
+++ b/tests/v0_tests/test_telemetry.py
@@ -28,9 +28,9 @@ class TestTelemetry(MarqoTestCase):
                 "Description": "Marqo is a very useful tool"}, ] * number_of_docs
 
         kwargs_list = [
-            {"documents": doc, "auto_refresh": True, "client_batch_size": None, "non_tensor_fields": None},
-            {"documents": doc, "auto_refresh": True, "client_batch_size": 5, "non_tensor_fields": None},
-            {"documents": doc, "auto_refresh": False, "client_batch_size": None, "non_tensor_fields": None},
+            {"documents": doc, "auto_refresh": True, "client_batch_size": None, "non_tensor_fields": []},
+            {"documents": doc, "auto_refresh": True, "client_batch_size": 5, "non_tensor_fields": []},
+            {"documents": doc, "auto_refresh": False, "client_batch_size": None, "non_tensor_fields": []},
             {"documents": doc, "auto_refresh": True, "client_batch_size": 2, "non_tensor_fields": ["Description"]},
             {"documents": doc, "auto_refresh": False, "client_batch_size": 3, "non_tensor_fields": ["Title"]},
         ]
@@ -57,7 +57,7 @@ class TestTelemetry(MarqoTestCase):
             {"q": "search query","searchable_attributes": ["Description"]}]
 
         self.client.create_index(self.index_name_1)
-        self.client.index(self.index_name_1).add_documents([{"Title": "A dummy document",}])
+        self.client.index(self.index_name_1).add_documents([{"Title": "A dummy document",}], tensor_fields=["Title"])
 
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.index(self.index_name_1).search, **search_kwargs_list[0])
@@ -69,7 +69,7 @@ class TestTelemetry(MarqoTestCase):
 
     def test_telemetry_bulk_search(self):
         self.client.create_index(self.index_name_1)
-        self.client.index(self.index_name_1).add_documents([{"Title": "A dummy document",}])
+        self.client.index(self.index_name_1).add_documents([{"Title": "A dummy document",}], tensor_fields=["Title"])
         bulk_search_query = [
             {
                 "index": self.index_name_1,
@@ -104,7 +104,8 @@ class TestTelemetry(MarqoTestCase):
 
     def test_telemetry_get_document(self):
         self.client.create_index(self.index_name_1)
-        self.client.index(self.index_name_1).add_documents([{"_id": "123321", "Title": "Marqo is useful",}])
+        self.client.index(self.index_name_1).add_documents([{"_id": "123321", "Title": "Marqo is useful",}],
+                                                           tensor_fields=["Title"])
         res = self.client.index(self.index_name_1).get_document("123321")
         self.assertIn("telemetry", res)
         self.assertEqual(res["telemetry"], dict())
@@ -112,7 +113,8 @@ class TestTelemetry(MarqoTestCase):
 
     def test_delete_documents(self):
         self.client.create_index(self.index_name_1)
-        self.client.index(self.index_name_1).add_documents([{"_id": "123321", "Title": "Marqo is useful",}])
+        self.client.index(self.index_name_1).add_documents([{"_id": "123321", "Title": "Marqo is useful",}],
+                                                           tensor_fields=["Title"])
         res = self.client.index(self.index_name_1).delete_documents(["123321"])
         self.assertIn("telemetry", res)
         self.assertEqual(res["telemetry"], dict())

--- a/tests/v0_tests/test_tensor_search.py
+++ b/tests/v0_tests/test_tensor_search.py
@@ -47,7 +47,7 @@ class TestSearch(MarqoTestCase):
             The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
             """
         }
-        add_doc_res = self.client.index(self.index_name_1).add_documents([d1])
+        add_doc_res = self.client.index(self.index_name_1).add_documents([d1], tensor_fields=["Title", "Description"])
         
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.index(self.index_name_1).search,
@@ -74,7 +74,7 @@ class TestSearch(MarqoTestCase):
     def test_search_highlights(self):
         """Tests if show_highlights works and if the deprecation behaviour is expected"""
         self.client.create_index(index_name=self.index_name_1)
-        self.client.index(index_name=self.index_name_1).add_documents([{"f1": "some doc"}])
+        self.client.index(index_name=self.index_name_1).add_documents([{"f1": "some doc"}], tensor_fields=["f1"])
         for params, expected_highlights_presence in [
                 ({"highlights": True, "show_highlights": False}, False),
                 ({"highlights": False, "show_highlights": True}, False),
@@ -108,7 +108,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ])
+        ], tensor_fields=["doc title", "field X"])
 
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.index(self.index_name_1).search,
@@ -134,7 +134,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ])
+        ], tensor_fields=['doc title', 'field X'])
 
         # Ensure that vector search works
         if self.IS_MULTI_INSTANCE:
@@ -207,7 +207,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ],auto_refresh=True)
+        ], tensor_fields=['doc title', 'field X', 'field1', 'abc-123', 'an_int'], auto_refresh=True)
 
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.index(self.index_name_1).search,
@@ -238,7 +238,7 @@ class TestSearch(MarqoTestCase):
         }
         x = self.client.index(self.index_name_1).add_documents([
             d1, d2
-        ], auto_refresh=True)
+        ], tensor_fields=['doc title', 'field X', 'field1', 'abc-123', 'an_int'], auto_refresh=True)
         atts = ["doc title", "an_int"]
         for search_method in [enums.SearchMethods.TENSOR,
                               enums.SearchMethods.LEXICAL]:
@@ -271,7 +271,7 @@ class TestSearch(MarqoTestCase):
                         for i in range(num_docs)]
         
         self.client.index(index_name=self.index_name_1).add_documents(
-            docs, auto_refresh=False, client_batch_size=50
+            docs, tensor_fields=["Title"], auto_refresh=False, client_batch_size=50
         )
         self.client.index(index_name=self.index_name_1).refresh()
 
@@ -325,7 +325,7 @@ class TestSearch(MarqoTestCase):
         }
         self.client.create_index(index_name=self.index_name_1, settings_dict=image_index_config)
         self.client.index(index_name=self.index_name_1).add_documents(
-            documents=docs, auto_refresh=True
+            documents=docs, tensor_fields=['loc a', 'loc b'], auto_refresh=True
         )
         queries_expected_ordering = [
             ({"Nature photography": 2.0, "Artefact": -2}, ['realistic_hippo', 'artefact_hippo']),


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
To add new documents to an index, `add_documents` receives `non_tensor_fields` and treats all fields except those in `non_tensor_fields` as tensor fields.

* **What is the new behavior (if this is a feature change)?**
`add_documents` will now accept `tensor_fields`. When this is provided, all fields not in `tensor_fields` are treated at non-tensor fields. This is in line with Marqo API changes in this PR https://github.com/marqo-ai/marqo/pull/538

`non_tensor_fields` is now marked as deprecated and using it will cause a warning, indicating that the field will be removed in Marqo 2.0.0.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. Not specifying `non_tensor_fields` previously led to all fields being treated as tensor fields. This will now lead to an error. 


* **Other information**:

