### PR TITLE
pin typing-extensions version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="1.2.0",
+    version="1.2.1",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
         "requests",
         "urllib3",
         "pydantic<2.0.0",
+        "typing-extensions>=4.5.0",
         "packaging"
     ],
     tests_require=[


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Version pin

* **What is the current behavior?** (You can also link to an open issue here)
Unpinned `typing-extensions` version results errors importing py-marqo on machines in environments with `typing-extensions` versions less than 4.5.0

* **What is the new behavior (if this is a feature change)?**
Enforces that typing-extensions must be at least 4.5.0

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Manual testing (to be done):**
- Have a `.venv` with typing-extensions 4.5.0 installed. Assert `pip install marqo` works and is usable
- Have a `.venv` with typing-extensions 4.4.0 installed. Assert `pip install marqo` ends up installing an up-to-date typing-extensions version  

