### PR TITLE
Remove time based cloud index URL cache refresh

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="1.2.3",
+    version="1.2.4",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="1.2.4",
+    version="1.2.3",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -68,13 +68,12 @@ class HttpRequests:
                 verify=True
             )
             return self._validate(response)
-        except MarqoWebError as err:
-            if index_name:
-                self.config.instance_mapping.on_instance_error(index_name, err.status_code)
-            raise err
         except requests.exceptions.Timeout as err:
             raise BackendTimeoutError(str(err)) from err
         except requests.exceptions.ConnectionError as err:
+            if index_name:
+                self.config.instance_mapping.on_instance_error(index_name)
+
             raise BackendCommunicationError(str(err)) from err
 
     def get(

--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -71,7 +71,7 @@ class HttpRequests:
         except MarqoWebError as err:
             if index_name:
                 self.config.instance_mapping.on_instance_error(index_name, err.status_code)
-                raise err
+            raise err
         except requests.exceptions.Timeout as err:
             raise BackendTimeoutError(str(err)) from err
         except requests.exceptions.ConnectionError as err:

--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -67,7 +67,7 @@ class HttpRequests:
                 data=body,
                 verify=True
             )
-            return self.__validate(response)
+            return self._validate(response)
         except MarqoWebError as err:
             if index_name:
                 self.config.instance_mapping.on_instance_error(index_name, err.status_code)
@@ -124,7 +124,7 @@ class HttpRequests:
         return request.json()
 
     @staticmethod
-    def __validate(
+    def _validate(
         request: requests.Response
     ) -> Any:
         try:

--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -72,7 +72,7 @@ class HttpRequests:
             raise BackendTimeoutError(str(err)) from err
         except requests.exceptions.ConnectionError as err:
             if index_name:
-                self.config.instance_mapping.on_instance_error(index_name)
+                self.config.instance_mapping.index_http_error_handler(index_name)
 
             raise BackendCommunicationError(str(err)) from err
 

--- a/src/marqo/_httprequests.py
+++ b/src/marqo/_httprequests.py
@@ -68,6 +68,10 @@ class HttpRequests:
                 verify=True
             )
             return self.__validate(response)
+        except MarqoWebError as err:
+            if index_name:
+                self.config.instance_mapping.on_instance_error(index_name, err.status_code)
+                raise err
         except requests.exceptions.Timeout as err:
             raise BackendTimeoutError(str(err)) from err
         except requests.exceptions.ConnectionError as err:

--- a/src/marqo/default_instance_mappings.py
+++ b/src/marqo/default_instance_mappings.py
@@ -25,3 +25,6 @@ class DefaultInstanceMappings(InstanceMappings):
 
     def is_remote(self):
         return self._is_remote
+
+    def on_instance_error(self, index_name: str, http_status: int) -> None:
+        return None

--- a/src/marqo/default_instance_mappings.py
+++ b/src/marqo/default_instance_mappings.py
@@ -26,5 +26,5 @@ class DefaultInstanceMappings(InstanceMappings):
     def is_remote(self):
         return self._is_remote
 
-    def on_instance_error(self, index_name: str, http_status: Optional[int] = None) -> None:
+    def index_http_error_handler(self, index_name: str, http_status: Optional[int] = None) -> None:
         return None

--- a/src/marqo/default_instance_mappings.py
+++ b/src/marqo/default_instance_mappings.py
@@ -26,5 +26,5 @@ class DefaultInstanceMappings(InstanceMappings):
     def is_remote(self):
         return self._is_remote
 
-    def on_instance_error(self, index_name: str, http_status: int) -> None:
+    def on_instance_error(self, index_name: str, http_status: Optional[int] = None) -> None:
         return None

--- a/src/marqo/instance_mappings.py
+++ b/src/marqo/instance_mappings.py
@@ -37,9 +37,9 @@ class InstanceMappings(ABC):
         pass
 
     @abstractmethod
-    def on_instance_error(self, index_name: str, http_status: Optional[int] = None) -> None:
+    def index_http_error_handler(self, index_name: str, http_status: Optional[int] = None) -> None:
         """
-        Called when an HTTP error occurs on a Marqo instance.
+        Called when an HTTP error occurs on a Marqo index operation.
 
         Args:
             index_name: The index name

--- a/src/marqo/instance_mappings.py
+++ b/src/marqo/instance_mappings.py
@@ -37,7 +37,7 @@ class InstanceMappings(ABC):
         pass
 
     @abstractmethod
-    def on_instance_error(self, index_name: str, http_status: int) -> None:
+    def on_instance_error(self, index_name: str, http_status: Optional[int] = None) -> None:
         """
         Called when an HTTP error occurs on a Marqo instance.
 

--- a/src/marqo/instance_mappings.py
+++ b/src/marqo/instance_mappings.py
@@ -35,3 +35,14 @@ class InstanceMappings(ABC):
     @abstractmethod
     def is_remote(self):
         pass
+
+    @abstractmethod
+    def on_instance_error(self, index_name: str, http_status: int) -> None:
+        """
+        Called when an HTTP error occurs on a Marqo instance.
+
+        Args:
+            index_name: The index name
+            http_status: The HTTP status code
+        """
+        pass

--- a/src/marqo/marqo_cloud_instance_mappings.py
+++ b/src/marqo/marqo_cloud_instance_mappings.py
@@ -39,10 +39,6 @@ class MarqoCloudInstanceMappings(InstanceMappings):
                 time.time() - self.latest_index_mappings_refresh_timestamp > self.url_cache_duration:
             # fast refresh to catch if index was created
             self._refresh_urls()
-        if index_name in self._urls_mapping['READY'] and \
-                time.time() - self.latest_index_mappings_refresh_timestamp > 360:
-            # slow refresh in case index was deleted
-            self._refresh_urls(timeout=3)
 
     def _refresh_urls(self, timeout=None):
         try:

--- a/src/marqo/marqo_cloud_instance_mappings.py
+++ b/src/marqo/marqo_cloud_instance_mappings.py
@@ -1,5 +1,4 @@
 import time
-from typing import Optional
 
 import requests
 from requests.exceptions import Timeout
@@ -41,6 +40,7 @@ class MarqoCloudInstanceMappings(InstanceMappings):
             self._refresh_urls()
 
     def _refresh_urls(self, timeout=None):
+        mq_logger.debug("Refreshing Marqo Cloud index URL cache")
         try:
             response = requests.get(f'{self.get_control_base_url()}/indexes',
                                     headers={"x-api-key": self.api_key}, timeout=timeout)
@@ -63,5 +63,7 @@ class MarqoCloudInstanceMappings(InstanceMappings):
 
     def on_instance_error(self, index_name: str, http_status: int) -> None:
         if http_status == 404:
+            mq_logger.debug(f'Evicting index {index_name} from cache (if exists) due to 404')
+
             self._urls_mapping['READY'].pop(index_name, None)
             self._urls_mapping['CREATING'].pop(index_name, None)

--- a/src/marqo/marqo_cloud_instance_mappings.py
+++ b/src/marqo/marqo_cloud_instance_mappings.py
@@ -69,5 +69,4 @@ class MarqoCloudInstanceMappings(InstanceMappings):
     def index_http_error_handler(self, index_name: str, http_status: Optional[int] = None) -> None:
         mq_logger.debug(f'Evicting index {index_name} from cache (if exists) due to error {http_status}')
 
-        self._urls_mapping['READY'].pop(index_name, None)
-        self._urls_mapping['CREATING'].pop(index_name, None)
+        self._refresh_urls()

--- a/src/marqo/marqo_cloud_instance_mappings.py
+++ b/src/marqo/marqo_cloud_instance_mappings.py
@@ -1,4 +1,5 @@
 import time
+from typing import Optional
 
 import requests
 from requests.exceptions import Timeout
@@ -65,9 +66,8 @@ class MarqoCloudInstanceMappings(InstanceMappings):
         if self._urls_mapping:
             self.latest_index_mappings_refresh_timestamp = time.time()
 
-    def on_instance_error(self, index_name: str, http_status: int) -> None:
-        if http_status == 404:
-            mq_logger.debug(f'Evicting index {index_name} from cache (if exists) due to 404')
+    def on_instance_error(self, index_name: str, http_status: Optional[int] = None) -> None:
+        mq_logger.debug(f'Evicting index {index_name} from cache (if exists) due to error {http_status}')
 
-            self._urls_mapping['READY'].pop(index_name, None)
-            self._urls_mapping['CREATING'].pop(index_name, None)
+        self._urls_mapping['READY'].pop(index_name, None)
+        self._urls_mapping['CREATING'].pop(index_name, None)

--- a/src/marqo/marqo_cloud_instance_mappings.py
+++ b/src/marqo/marqo_cloud_instance_mappings.py
@@ -67,6 +67,9 @@ class MarqoCloudInstanceMappings(InstanceMappings):
             self.latest_index_mappings_refresh_timestamp = time.time()
 
     def index_http_error_handler(self, index_name: str, http_status: Optional[int] = None) -> None:
-        mq_logger.debug(f'Refreshing cache due to error {http_status} on index {index_name}')
+        mq_logger.debug(f'Evicting index {index_name} from cache (if exists) due to error {http_status} and '
+                        f'refreshing index URL cache')
 
-        self._refresh_urls()
+        self._urls_mapping[IndexStatus.READY].pop(index_name, None)
+
+        self._refresh_urls_if_needed(index_name)

--- a/src/marqo/marqo_cloud_instance_mappings.py
+++ b/src/marqo/marqo_cloud_instance_mappings.py
@@ -60,3 +60,8 @@ class MarqoCloudInstanceMappings(InstanceMappings):
                 self._urls_mapping[index['index_status']][index['index_name']] = index.get('endpoint')
         if self._urls_mapping:
             self.latest_index_mappings_refresh_timestamp = time.time()
+
+    def on_instance_error(self, index_name: str, http_status: int) -> None:
+        if http_status == 404:
+            self._urls_mapping['READY'].pop(index_name, None)
+            self._urls_mapping['CREATING'].pop(index_name, None)

--- a/src/marqo/marqo_cloud_instance_mappings.py
+++ b/src/marqo/marqo_cloud_instance_mappings.py
@@ -66,7 +66,7 @@ class MarqoCloudInstanceMappings(InstanceMappings):
         if self._urls_mapping:
             self.latest_index_mappings_refresh_timestamp = time.time()
 
-    def on_instance_error(self, index_name: str, http_status: Optional[int] = None) -> None:
+    def index_http_error_handler(self, index_name: str, http_status: Optional[int] = None) -> None:
         mq_logger.debug(f'Evicting index {index_name} from cache (if exists) due to error {http_status}')
 
         self._urls_mapping['READY'].pop(index_name, None)

--- a/src/marqo/marqo_cloud_instance_mappings.py
+++ b/src/marqo/marqo_cloud_instance_mappings.py
@@ -67,6 +67,6 @@ class MarqoCloudInstanceMappings(InstanceMappings):
             self.latest_index_mappings_refresh_timestamp = time.time()
 
     def index_http_error_handler(self, index_name: str, http_status: Optional[int] = None) -> None:
-        mq_logger.debug(f'Evicting index {index_name} from cache (if exists) due to error {http_status}')
+        mq_logger.debug(f'Refreshing cache due to error {http_status} on index {index_name}')
 
         self._refresh_urls()

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -226,7 +226,7 @@ class MarqoTestCase(TestCase):
             - Please note that settings_dict overrides any kwargs during index creation.
         """
         client = marqo.Client(**self.client_settings)
-        index_name = f"{index_name}-{self.index_suffix}"
+        index_name = f"{index_name}" + (f"-{self.index_suffix}" if self.index_suffix else "")
         if settings_dict or kwargs:
             index_name = f"{index_name}-{create_settings_hash(settings_dict, kwargs)}"
         if settings_dict:

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -231,7 +231,7 @@ class MarqoTestCase(TestCase):
             index_name = f"{index_name}-{create_settings_hash(settings_dict, kwargs)}"
         if settings_dict:
             settings_dict.update({
-                "inference_type": "marqo.CPU", "storage_class": "marqo.basic"
+                "inference_type": "marqo.CPU.large", "storage_class": "marqo.basic"
             })
 
         if len(index_name) > 32:

--- a/tests/v0_tests/test__httprequests.py
+++ b/tests/v0_tests/test__httprequests.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
+import requests.exceptions
+
 from marqo._httprequests import HttpRequests
 from marqo.config import Config
 from marqo.default_instance_mappings import DefaultInstanceMappings
@@ -40,7 +42,7 @@ class TestConstructPath(unittest.TestCase):
     def test_send_request_calls_on_instance_error(self, mock_on_instance_error: MagicMock, mock_validate: MagicMock,
                                                   mock_requests: MagicMock,):
         # Set up mock behavior to raise MarqoWebError
-        mock_validate.side_effect = MarqoWebError(message="Not Found", status_code=404)
+        mock_validate.side_effect = requests.exceptions.ConnectionError()
 
         http_requests = HttpRequests(config=Config(instance_mappings=DefaultInstanceMappings(self.base_url)))
 
@@ -48,4 +50,4 @@ class TestConstructPath(unittest.TestCase):
             http_requests.get('/', index_name="test_index")
 
         mock_on_instance_error.assert_called_once()
-        mock_on_instance_error.assert_called_with("test_index", 404)
+        mock_on_instance_error.assert_called_with("test_index")

--- a/tests/v0_tests/test__httprequests.py
+++ b/tests/v0_tests/test__httprequests.py
@@ -1,7 +1,11 @@
 import unittest
+from unittest.mock import patch, MagicMock
+
 from marqo._httprequests import HttpRequests
 from marqo.config import Config
 from marqo.default_instance_mappings import DefaultInstanceMappings
+from marqo.errors import MarqoWebError
+
 
 class TestConstructPath(unittest.TestCase):
 
@@ -29,3 +33,19 @@ class TestConstructPath(unittest.TestCase):
     def test_construct_path_with_no_telemetry_parameter(self):
         result = self.construct_path_helper("testpath")
         self.assertEqual(result, f"{self.base_url}/testpath")
+
+    @patch("requests.sessions.Session.request")
+    @patch("marqo._httprequests.HttpRequests._validate")
+    @patch("marqo.default_instance_mappings.DefaultInstanceMappings.on_instance_error")
+    def test_send_request_calls_on_instance_error(self, mock_on_instance_error: MagicMock, mock_validate: MagicMock,
+                                                  mock_requests: MagicMock,):
+        # Set up mock behavior to raise MarqoWebError
+        mock_validate.side_effect = MarqoWebError(message="Not Found", status_code=404)
+
+        http_requests = HttpRequests(config=Config(instance_mappings=DefaultInstanceMappings(self.base_url)))
+
+        with self.assertRaises(MarqoWebError):
+            http_requests.get('/', index_name="test_index")
+
+        mock_on_instance_error.assert_called_once()
+        mock_on_instance_error.assert_called_with("test_index", 404)

--- a/tests/v0_tests/test__httprequests.py
+++ b/tests/v0_tests/test__httprequests.py
@@ -38,9 +38,9 @@ class TestConstructPath(unittest.TestCase):
 
     @patch("requests.sessions.Session.request")
     @patch("marqo._httprequests.HttpRequests._validate")
-    @patch("marqo.default_instance_mappings.DefaultInstanceMappings.on_instance_error")
-    def test_send_request_calls_on_instance_error(self, mock_on_instance_error: MagicMock, mock_validate: MagicMock,
-                                                  mock_requests: MagicMock,):
+    @patch("marqo.default_instance_mappings.DefaultInstanceMappings.index_http_error_handler")
+    def test_send_request_calls_index_http_error_handler(self, mock_index_http_error_handler: MagicMock, mock_validate: MagicMock,
+                                                  mock_requests: MagicMock, ):
         # Set up mock behavior to raise MarqoWebError
         mock_validate.side_effect = requests.exceptions.ConnectionError()
 
@@ -49,5 +49,5 @@ class TestConstructPath(unittest.TestCase):
         with self.assertRaises(MarqoWebError):
             http_requests.get('/', index_name="test_index")
 
-        mock_on_instance_error.assert_called_once()
-        mock_on_instance_error.assert_called_with("test_index")
+        mock_index_http_error_handler.assert_called_once()
+        mock_index_http_error_handler.assert_called_with("test_index")

--- a/tests/v0_tests/test_index.py
+++ b/tests/v0_tests/test_index.py
@@ -224,7 +224,7 @@ class TestIndex(MarqoTestCase):
         self.client.config.is_marqo_cloud = True
 
         result = self.client.create_index(
-            index_name=self.generic_test_index_name, inference_node_type="marqo.CPU", inference_node_count=1,
+            index_name=self.generic_test_index_name, inference_node_type="marqo.CPU.large", inference_node_count=1,
             storage_node_type="marqo.basic"
         )
 
@@ -235,7 +235,7 @@ class TestIndex(MarqoTestCase):
                 'image_preprocessing': {'patch_method': None}
             },
             'number_of_shards': 1, 'number_of_replicas': 0,
-            'inference_type': "marqo.CPU", 'storage_class': "marqo.basic", 'number_of_inferences': 1})
+            'inference_type': "marqo.CPU.large", 'storage_class': "marqo.basic", 'number_of_inferences': 1})
         mock_get.assert_called_with("indexes/test-index/status")
         assert result == {"acknowledged": True}
 
@@ -270,7 +270,7 @@ class TestIndex(MarqoTestCase):
         self.client.config.is_marqo_cloud = True
 
         result = self.client.create_index(
-            index_name=self.generic_test_index_name, inference_node_type="marqo.CPU", inference_node_count=1,
+            index_name=self.generic_test_index_name, inference_node_type="marqo.CPU.large", inference_node_count=1,
             storage_node_type=None
         )
 
@@ -281,7 +281,7 @@ class TestIndex(MarqoTestCase):
                 'image_preprocessing': {'patch_method': None}
             },
             'number_of_shards': 1, 'number_of_replicas': 0,
-            'inference_type': "marqo.CPU", 'storage_class': None, 'number_of_inferences': 1})
+            'inference_type': "marqo.CPU.large", 'storage_class': None, 'number_of_inferences': 1})
         mock_get.assert_called_with("indexes/test-index/status")
         assert result == {"error": "storage_class is required"}
 
@@ -294,7 +294,7 @@ class TestIndex(MarqoTestCase):
         self.client.config.is_marqo_cloud = True
 
         result = self.client.create_index(
-            index_name=self.generic_test_index_name, inference_node_type="marqo.CPU", inference_node_count=-1,
+            index_name=self.generic_test_index_name, inference_node_type="marqo.CPU.large", inference_node_count=-1,
             storage_node_type="marqo.basic"
         )
 
@@ -305,7 +305,7 @@ class TestIndex(MarqoTestCase):
                 'image_preprocessing': {'patch_method': None}
             },
             'number_of_shards': 1, 'number_of_replicas': 0,
-            'inference_type': "marqo.CPU", 'storage_class': "marqo.basic", 'number_of_inferences': -1})
+            'inference_type': "marqo.CPU.large", 'storage_class': "marqo.basic", 'number_of_inferences': -1})
         mock_get.assert_called_with("indexes/test-index/status")
         assert result == {"error": "inference_node_count must be greater than 0"}
 

--- a/tests/v0_tests/test_marqo_cloud_instance_mapping.py
+++ b/tests/v0_tests/test_marqo_cloud_instance_mapping.py
@@ -213,15 +213,11 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
             'https://dummy-url-e0244394-4383-4869-b633-46e6fe4a3ac1.dp1.marqo.ai'
 
         with mock.patch('marqo.index.Index._marqo_minimum_supported_version_check'):
-            # Disable version check otherwise it'll cause cache eviction and we get IndexNotFound instead
+            # Disable version check otherwise it'll cause cache eviction before we want it to happen
             with self.assertRaises(BackendCommunicationError):
                 self.client.index(self.generic_test_index_name).search('test query')
 
         assert self.generic_test_index_name not in mappings._urls_mapping[IndexStatus.READY]
-
-        # Second time we expect a cache refresh and index not found
-        with self.assertRaises(MarqoCloudIndexNotFoundError):
-            self.client.index(self.generic_test_index_name).search('test query')
 
         self.create_test_index(self.generic_test_index_name)
 

--- a/tests/v0_tests/test_marqo_cloud_instance_mapping.py
+++ b/tests/v0_tests/test_marqo_cloud_instance_mapping.py
@@ -1,5 +1,5 @@
 import time
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from marqo.marqo_cloud_instance_mappings import MarqoCloudInstanceMappings
 from tests.marqo_test import MarqoTestCase
@@ -33,7 +33,7 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
         }
 
     @patch("requests.get")
-    def test_refresh_urls_if_not_needed(self, mock_get):
+    def test_refresh_urls_if_not_needed(self, mock_get: MagicMock):
         mock_get.return_value.json.return_value = {"results": [
             {"index_name": "index1", "endpoint": "example.com", "index_status": "READY"},
             {"index_name": "index2", "endpoint": "example2.com", "index_status": "READY"}
@@ -50,7 +50,7 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
 
         # Check that the timestamp has not been updated
         assert mapping.latest_index_mappings_refresh_timestamp == initial_timestamp
-        assert mock_get.called_once()
+        mock_get.assert_called_once()
 
         # Check that the URLs mapping has been initially populated
         assert mapping._urls_mapping["READY"] == {

--- a/tests/v0_tests/test_marqo_cloud_instance_mapping.py
+++ b/tests/v0_tests/test_marqo_cloud_instance_mapping.py
@@ -380,7 +380,7 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
         mappings._urls_mapping[IndexStatus.READY]['index2'] = "example.com"
         mappings._urls_mapping[IndexStatus.CREATING]['index1'] = "example.com"
 
-        mappings.on_instance_error('index1')
+        mappings.index_http_error_handler('index1')
 
         self.assertEqual(mappings._urls_mapping,
                          {IndexStatus.READY: {'index2': 'example.com'}, IndexStatus.CREATING: {}}
@@ -394,7 +394,7 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
         mappings._urls_mapping[IndexStatus.READY]['index2'] = "example.com"
         mappings._urls_mapping[IndexStatus.CREATING]['index1'] = "example.com"
 
-        mappings.on_instance_error('index3')
+        mappings.index_http_error_handler('index3')
 
         self.assertEqual(mappings._urls_mapping,
                          {IndexStatus.READY: {'index1': 'example.com', 'index2': 'example.com'},

--- a/tests/v0_tests/test_marqo_cloud_instance_mapping.py
+++ b/tests/v0_tests/test_marqo_cloud_instance_mapping.py
@@ -283,7 +283,8 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
         # cache has not expired, url is still returned
         assert mapping.get_index_base_url("index1") == "example.com"
 
-        mapping.latest_index_mappings_refresh_timestamp = time.time() - 366
+        # Trigger cache eviction for this index
+        mapping.index_http_error_handler("index1")
         with self.assertRaises(MarqoCloudIndexNotFoundError):
             mapping.get_index_base_url("index1")
 
@@ -326,7 +327,8 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
         # cache has not expired, url is still returned
         assert mapping.get_index_base_url("index1") == "example.com"
 
-        mapping.latest_index_mappings_refresh_timestamp = time.time() - 366
+        # Trigger cache eviction for this index
+        mapping.index_http_error_handler("index1")
         with self.assertRaises(MarqoCloudIndexNotFoundError):
             mapping.get_index_base_url("index1")
 
@@ -368,7 +370,7 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
         idx.search("test")
         assert self.client.config.instance_mapping.latest_index_mappings_refresh_timestamp == last_refresh
 
-    def test_on_instance_error_existing_index(self):
+    def test_index_http_error_handler_existing_index(self):
         mappings = MarqoCloudInstanceMappings(
             control_base_url="https://api.marqo.ai", api_key="your-api-key"
         )
@@ -382,7 +384,7 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
                          {IndexStatus.READY: {'index2': 'example.com'}, IndexStatus.CREATING: {}}
                          )
 
-    def test_on_instance_error_missing_index(self):
+    def test_index_http_error_handler_missing_index(self):
         mappings = MarqoCloudInstanceMappings(
             control_base_url="https://api.marqo.ai", api_key="your-api-key"
         )


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Performance improvement

* **What is the current behavior?** (You can also link to an open issue here)
Marqo Cloud index URL cache refreshes every 6 minutes

* **What is the new behavior (if this is a feature change)?**
Cache will only refresh if we try to resolve an index for which there is no URL in cache. Furthermore, Marqo client evicts index cached URL if there's a `ConnectionError` when trying to reach the data plane. This means the next request on that index will trigger a cache refresh.

The following behaviour is expected:
* If the user deletes an index after it's been cached (e.g., searched), the first request on that index will return `BackendCommunicationError`. Any further attempts to reach the deleted index will return `MarqoCloudIndexNotFoundError`.
* If the user deletes an index after it's been cached, and creates a new index with the same name, the first attempt to access the new index with the same client instance will return a `BackendCommunicationError`. Further attempts will resolve to the new index correctly.
* Arbitrary network issues on a valid index will lead to cache eviction and refresh on the next request (but refresh frequency is capped at one per 15 seconds regardless).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

