### PR TITLE
Improve cache refresh on error

### DIFF
--- a/tests/v0_tests/test_marqo_cloud_instance_mapping.py
+++ b/tests/v0_tests/test_marqo_cloud_instance_mapping.py
@@ -183,7 +183,8 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
             assert mapping.get_index_base_url("index1") == "example.com"
             mock_warning.assert_called_once()
             assert str(mock_warning.call_args[0][0]) == mock_get.return_value.text
-            self.assertRaises(MarqoCloudIndexNotFoundError, mapping.get_index_base_url, "index2")
+            # Ensure cache has maintained the old value
+            assert mapping.get_index_base_url("index2") == "example2.com"
 
     @patch("requests.get")
     def test_get_indexes_fails_cache_updates(self, mock_get):
@@ -368,7 +369,8 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
         # cache has not expired, url is still returned
         assert mapping.get_index_base_url("index1") == "example.com"
 
-        # Trigger cache eviction for this index
+        # Trigger cache refresh, wait 1 second to ensure refresh isn't skipped
+        time.sleep(1)
         mapping.index_http_error_handler("index1")
         with self.assertRaises(MarqoCloudIndexNotFoundError):
             mapping.get_index_base_url("index1")


### PR DESCRIPTION
On ConnectionError, do not evict existing index URL prior to cache refresh. This is to avoid an incorrect `IndexNotFound` when a data plane is returning ConnectionError for other reasons. A repeated `ConnectionError` with cache eviction means the index is removed from cache, but cache isn't refreshed (due to cache duration not having passed). This will look like a missing index.