### PR TITLE
Fix test_when_needed_http_request_for_get_indexes_is_sent

### DIFF
--- a/tests/v0_tests/test_marqo_cloud_instance_mapping.py
+++ b/tests/v0_tests/test_marqo_cloud_instance_mapping.py
@@ -401,6 +401,11 @@ class TestMarqoCloudInstanceMappings(MarqoTestCase):
             with self.assertRaises(BackendCommunicationError):
                 ix2 = self.client.index(test_index_name)
                 ix2.search("test")
+
+            # the timestamp should be updated along with the refresh:
+            assert (simulated_last_reset_time
+                < self.client.config.instance_mapping.latest_index_mappings_refresh_timestamp)
+
             assert mock_post.call_count == 2
             # mappings refresh is triggered due to the error:
             assert mock_get.call_count == 1


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Test fix

* **What is the current behavior?** (You can also link to an open issue here)
test_when_needed_http_request_for_get_indexes_is_sent doesn't work when testing against the cloud env

* **What is the new behavior (if this is a feature change)?**
test_when_needed_http_request_for_get_indexes_is_sent now works when testing against the cloud env


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:
Passes cloud test:
<img width="1355" alt="image" src="https://github.com/marqo-ai/py-marqo/assets/107458762/be869fa7-2ac3-44a9-810e-ada93ebb1173">

