### PR TITLE
Remove average calculation in add documents

### DIFF
--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -411,8 +411,7 @@ class Index:
 
         end_time_client_process = timer()
         total_client_process_time = end_time_client_process - start_time_client_process
-        mq_logger.debug(f"add_documents pre-processing: took {(total_client_process_time):.3f}s for {num_docs} docs, "
-                       f"for an average of {(total_client_process_time / num_docs):.3f}s per doc.")
+        mq_logger.debug(f"add_documents pre-processing: took {(total_client_process_time):.3f}s for {num_docs} docs.")
 
         if client_batch_size is not None:
             if client_batch_size <= 0:
@@ -439,12 +438,12 @@ class Index:
             total_client_request_time = end_time_client_request - start_time_client_request
 
             mq_logger.debug(f"add_documents roundtrip: took {(total_client_request_time):.3f}s to send {num_docs} "
-                            f"docs to Marqo (roundtrip, unbatched), for an average of {(total_client_request_time / num_docs):.3f}s per doc.")
+                            f"docs to Marqo (roundtrip, unbatched).")
             errors_detected = False
 
             if 'processingTimeMs' in res:       # Only outputs log if response is non-empty
                 mq_logger.debug(f"add_documents Marqo index: took {(res['processingTimeMs'] / 1000):.3f}s for Marqo to process & index {num_docs} "
-                                f"docs (server unbatched), for an average of {(res['processingTimeMs'] / (1000 * num_docs)):.3f}s per doc.")
+                                f"docs.")
             if 'errors' in res and res['errors']:
                 mq_logger.info(error_detected_message)
             if errors_detected:
@@ -533,8 +532,7 @@ class Index:
             if isinstance(res, list):
                 # with Server Batching (show processing time for each batch)
                 mq_logger.info(
-                    f"    add_documents batch {i} roundtrip: took {(total_batch_time):.3f}s to add {num_docs} docs, "
-                    f"for an average of {(total_batch_time / num_docs):.3f}s per doc.")
+                    f"    add_documents batch {i} roundtrip: took {(total_batch_time):.3f}s to add {num_docs} docs.")
 
                 if isinstance(res[0], list):
                     # for multiprocess, timing messages should be arranged by process, then batch
@@ -544,8 +542,7 @@ class Index:
                         for batch in range(len(res[process])):
                             server_batch_result_count = len(res[process][batch]["items"])
                             mq_logger.debug(f"           marqo server batch {batch}: "
-                                            f"processed {server_batch_result_count} docs in {(res[process][batch]['processingTimeMs'] / 1000):.3f}s, "
-                                            f"for an average of {(res[process][batch]['processingTimeMs'] / (1000 * server_batch_result_count)):.3f}s per doc.")
+                                            f"processed {server_batch_result_count} docs in {(res[process][batch]['processingTimeMs'] / 1000):.3f}s.")
                             if 'errors' in res[process][batch] and res[process][batch]['errors']:
                                 errors_detected = True
 
@@ -554,17 +551,15 @@ class Index:
                     for batch in range(len(res)):
                         server_batch_result_count = len(res[batch]["items"])
                         mq_logger.debug(f"       marqo server batch {batch}: "
-                                        f"processed {server_batch_result_count} docs in {(res[batch]['processingTimeMs'] / 1000):.3f}s, "
-                                        f"for an average of {(res[batch]['processingTimeMs'] / (1000 * server_batch_result_count)):.3f}s per doc.")
+                                        f"processed {server_batch_result_count} docs in {(res[batch]['processingTimeMs'] / 1000):.3f}s.")
                         if 'errors' in res[batch] and res[batch]['errors']:
                             errors_detected = True
             else:
                 # no Server Batching
                 if 'processingTimeMs' in res:       # Only outputs log if response is non-empty
                     mq_logger.info(
-                        f"    add_documents batch {i}: took {(res['processingTimeMs'] / 1000):.3f}s for Marqo to process & index {num_docs} "
-                        f"docs (server unbatched), for an average of {(res['processingTimeMs'] / (1000 * num_docs)):.3f}s per doc."
-                        f" Roundtrip time: {(total_batch_time):.3f}s")
+                        f"    add_documents batch {i}: took {(res['processingTimeMs'] / 1000):.3f}s for Marqo to process & index {num_docs} docs."
+                        f" Roundtrip time: {(total_batch_time):.3f}s.")
                     if 'errors' in res and res['errors']:
                         errors_detected = True
 

--- a/tests/v0_tests/test_add_documents.py
+++ b/tests/v0_tests/test_add_documents.py
@@ -614,3 +614,25 @@ class TestAddDocuments(MarqoTestCase):
             )
             self.client.index(test_index_name).add_documents(documents=documents, non_tensor_fields=non_tensor_fields)
             self.assertTrue({'`non_tensor_fields`', 'Marqo', '2.0.0.'}.issubset(set(cm.output[0].split(" "))))
+
+    def test_add_empty_docs(self):
+        test_index_name = self.create_test_index(
+            cloud_test_index_to_use=CloudTestIndex.basic_index,
+            open_source_test_index_name=self.generic_test_index_name,
+        )
+
+        try:
+            res = self.client.index(test_index_name).add_documents(documents=[], tensor_fields=["field a"])
+            raise AssertionError
+        except MarqoWebError as e:
+            assert e.code == "bad_request"
+            assert "empty add documents request" in e.message["message"]
+    
+    def test_add_empty_docs_batched(self):
+        test_index_name = self.create_test_index(
+            cloud_test_index_to_use=CloudTestIndex.basic_index,
+            open_source_test_index_name=self.generic_test_index_name,
+        )
+
+        res = self.client.index(test_index_name).add_documents(documents=[], client_batch_size=5, tensor_fields="field a")
+        assert res == []


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Average time calculation is done in client for batched calls. This results in a division by 0 error for empty add docs calls.

* **What is the new behavior (if this is a feature change)?**
No more average time calculation is done. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No (unless users are collecting this print statement and using it in their code)

* **Other information**:
Is it necessary to add different error types for cloud in my tests @danyilq ? See test `test_add_empty_docs`
