### PR TITLE
Set default auto_refresh to None

### DIFF
--- a/tests/v0_tests/test_delete_documents.py
+++ b/tests/v0_tests/test_delete_documents.py
@@ -1,0 +1,106 @@
+import copy
+import functools
+import math
+import pprint
+import random
+import pytest
+import requests
+import time
+
+from pytest import mark
+
+from marqo.errors import MarqoError, MarqoWebError
+from tests.marqo_test import MarqoTestCase, CloudTestIndex
+from marqo import enums
+from unittest import mock
+
+
+class TestDeleteDocuments(MarqoTestCase):
+    def test_delete_docs(self):
+        test_index_name = self.create_test_index(
+            cloud_test_index_to_use=CloudTestIndex.basic_index,
+            open_source_test_index_name=self.generic_test_index_name,
+        )
+        self.client.index(test_index_name).add_documents([
+            {"abc": "wow camel", "_id": "123"},
+            {"abc": "camels are cool", "_id": "foo"}
+        ], tensor_fields=["abc"])
+
+        if self.IS_MULTI_INSTANCE:
+            self.warm_request(self.client.index(test_index_name).search, "wow camel")
+
+        res0 = self.client.index(test_index_name).search("wow camel")
+        assert res0['hits'][0]["_id"] == "123"
+        assert len(res0['hits']) == 2
+        self.client.index(test_index_name).delete_documents(["123"])
+
+        if self.IS_MULTI_INSTANCE:
+            self.warm_request(self.client.index(test_index_name).search, "wow camel")
+        res1 = self.client.index(test_index_name).search("wow camel")
+        assert res1['hits'][0]["_id"] == "foo"
+        assert len(res1['hits']) == 1
+    
+    def test_delete_documents_defaults(self):
+        """
+        Ensure that the expected default values are used for the delete documents API call
+        Note that some parameters should have no default created by the client, thus should
+        not be present in the request.
+        """
+        temp_client = copy.deepcopy(self.client)
+        mock__post = mock.MagicMock()
+
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            temp_client.index(self.generic_test_index_name).delete_documents(
+                ids=['0', '1', '2'], 
+            )
+            return True
+
+        assert run()
+
+        args, kwargs0 = mock__post.call_args_list[0]
+
+       # Ensure client does NOT autofill refresh parameter
+        assert "refresh" not in kwargs0["path"]
+        # These parameters were explicitly defined:
+        assert kwargs0["body"] == ['0', '1', '2']
+
+    def test_delete_docs_with_refresh(self):
+        """
+        Ensure that refresh parameter for delete docs is properly set in API call
+        """
+        temp_client = copy.deepcopy(self.client)
+        mock__post = mock.MagicMock()
+
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            temp_client.index(self.generic_test_index_name).delete_documents(
+                ids=['0', '1', '2'], auto_refresh=True
+            )
+            temp_client.index(self.generic_test_index_name).delete_documents(
+                ids=['0', '1', '2'], auto_refresh=False
+            )
+            return True
+
+        assert run()
+
+        args, kwargs0 = mock__post.call_args_list[0]
+        args, kwargs1 = mock__post.call_args_list[1]
+
+        assert "refresh=true" in kwargs0["path"]
+        assert "refresh=false" in kwargs1["path"]
+
+
+    def test_delete_docs_empty_ids(self):
+        test_index_name = self.create_test_index(
+            cloud_test_index_to_use=CloudTestIndex.basic_index,
+            open_source_test_index_name=self.generic_test_index_name,
+        )
+        self.client.index(test_index_name).add_documents([{"abc": "efg", "_id": "123"}], tensor_fields=["abc"])
+        try:
+            self.client.index(test_index_name).delete_documents([])
+            raise AssertionError
+        except MarqoWebError as e:
+            assert "can't be empty" in str(e) or "value_error.missing" in str(e)
+        res = self.client.index(test_index_name).get_document("123")
+        assert "abc" in res

--- a/tests/v0_tests/test_model_auth.py
+++ b/tests/v0_tests/test_model_auth.py
@@ -39,7 +39,8 @@ class TestAddDocumentsModelAuth(MarqoTestCase):
                 _, kwargs = call
                 assert expected_str in kwargs['path'] or ('refresh' in kwargs['path'])
 
-            assert len(mock__post.call_args_list) == 3
+            # 2 batches (10 docs each). No refresh call.
+            assert len(mock__post.call_args_list) == 2
 
             return True
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
Default `auto_refresh` for `add_documents` and `delete_documents` is `True`.

* **What is the new behavior (if this is a feature change)?**
Default `auto_refresh` for `add_documents` and `delete_documents` is now `None`. The API call to marqo will omit this query parameter if not specified.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. `auto_refresh` will now need to be set manually.

* **Other information**:
Marqo PR: https://github.com/marqo-ai/marqo/pull/601
