### PR TITLE
add sleep call to allow automatic refresh to occur

### DIFF
--- a/tests/v0_tests/test_add_documents.py
+++ b/tests/v0_tests/test_add_documents.py
@@ -198,6 +198,7 @@ class TestAddDocuments(MarqoTestCase):
         assert len(docs) == 100
         ix.add_documents(docs, client_batch_size=4, tensor_fields=["Title", "Generic text"])
         ix.refresh()
+        time.sleep(3)
         # takes too long to search for all...
         for _id in [0, 19, 20, 99]:
             original_doc = docs[_id].copy()

--- a/tests/v0_tests/test_bulk_search.py
+++ b/tests/v0_tests/test_bulk_search.py
@@ -1,3 +1,4 @@
+import time
 import copy
 import os
 
@@ -476,6 +477,7 @@ class TestBulkSearch(MarqoTestCase):
             docs, auto_refresh=False, client_batch_size=50, tensor_fields=["Title"]
         )
         self.client.index(test_index_name).refresh()
+        time.sleep(3)
 
         for search_method in (enums.SearchMethods.TENSOR, enums.SearchMethods.LEXICAL):
             for doc_count in [100]:

--- a/tests/v0_tests/test_tensor_search.py
+++ b/tests/v0_tests/test_tensor_search.py
@@ -448,6 +448,7 @@ class TestSearch(MarqoTestCase):
             docs, tensor_fields=["Title"], auto_refresh=False, client_batch_size=50
         )
         self.client.index(index_name=test_index_name).refresh()
+        time.sleep(3)
 
         for search_method in (enums.SearchMethods.TENSOR, enums.SearchMethods.LEXICAL):
             for doc_count in [100]:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** 
This PR includes fixes that allow tests that require .refresh() to pass due to the recent silent blocking of the `/refresh` endpoint on cloud reverse proxy.

* **What is the current behavior?** (You can also link to an open issue here)
some tests fail due to inconsistencies in the document count since we silently block the `/refresh` endpoint on cloud.

* **What is the new behavior (if this is a feature change)?**
Adding some sleep calls allow the index to rely on the automatic refresh built in by marqo to update the documents on the index.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Screenshot of tests now passing on my local machine
![image](https://github.com/marqo-ai/py-marqo/assets/112362822/a759b01e-83d4-4541-9b01-e8dcbc059240)

