### PR TITLE
add auto_refresh=True to add and delete docs calls

### DIFF
--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__marqo_version__ = "1.3.0"
+__marqo_version__ = "1.4.0"
 __marqo_release_page__ = f"https://github.com/marqo-ai/marqo/releases/tag/{__marqo_version__}"
 
 __minimum_supported_marqo_version__ = "1.0.0"

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -163,7 +163,7 @@ def with_documents(index_to_documents_fn: Callable[[], Dict[str, List[Dict[str, 
                     cloud_test_index_to_use=CloudTestIndex.basic_index,
                     open_source_test_index_name=index_name
                 )
-                self.client.index(index_name).add_documents(docs, non_tensor_fields=[])
+                self.client.index(index_name).add_documents(docs, non_tensor_fields=[], auto_refresh=True)
                 if self.IS_MULTI_INSTANCE:
                     self.warm_request(self.client.bulk_search, [{
                         "index": index_name,

--- a/tests/v0_tests/test_add_documents.py
+++ b/tests/v0_tests/test_add_documents.py
@@ -253,13 +253,13 @@ class TestAddDocuments(MarqoTestCase):
         def run():
             temp_client.index(self.generic_test_index_name).add_documents(documents=[
                 {"d1": "blah"}, {"d2": "some data"}, {"d2331": "blah"}, {"45d2": "some data"}
-            ], client_batch_size=2, device="cuda:37", tensor_fields=["d1", "d2", "d2331", "45d2"], auto_refresh=True)
+            ], client_batch_size=2, device="cuda:37", tensor_fields=["d1", "d2", "d2331", "45d2"])
             return True
 
         assert run()
 
         print(mock__post.call_args_list)
-        assert len(mock__post.call_args_list) == 2
+        assert len(mock__post.call_args_list) == 2      # 2 batches, no refresh
         for args, kwargs in mock__post.call_args_list:
             assert "device=cuda37" in kwargs["path"]
 

--- a/tests/v0_tests/test_add_documents.py
+++ b/tests/v0_tests/test_add_documents.py
@@ -130,7 +130,7 @@ class TestAddDocuments(MarqoTestCase):
         }
         res = self.client.index(test_index_name).add_documents([
             d1, d2
-        ], tensor_fields=["field X", "field 1", "doc title"])
+        ], tensor_fields=["field X", "field 1", "doc title"], auto_refresh=True)
         retrieved_d1 = self.client.index(test_index_name).get_document(
             document_id="e197e580-0393-4f4e-90e9-8cdf4b17e339")
         assert retrieved_d1 == d1
@@ -151,7 +151,7 @@ class TestAddDocuments(MarqoTestCase):
             "doc title": "Just Your Average Doc",
             "field X": "this is a solid doc"
         }
-        res = self.client.index(test_index_name).add_documents([d1, d2], tensor_fields=["field X", "field 1", "doc title"])
+        res = self.client.index(test_index_name).add_documents([d1, d2], tensor_fields=["field X", "field 1", "doc title"], auto_refresh=True)
         ids = [item["_id"] for item in res["items"]]
         assert len(ids) == 2
         assert ids[0] != ids[1]
@@ -172,14 +172,14 @@ class TestAddDocuments(MarqoTestCase):
             "field X": "this is a solid doc",
             "_id": "56"
         }
-        self.client.index(test_index_name).add_documents([d1], tensor_fields=["field X", "doc title"])
+        self.client.index(test_index_name).add_documents([d1], tensor_fields=["field X", "doc title"], auto_refresh=True)
         assert d1 == self.client.index(test_index_name).get_document("56")
         d2 = {
             "_id": "56",
             "completely": "different doc.",
             "field X": "this is a solid doc"
         }
-        self.client.index(test_index_name).add_documents([d2], tensor_fields=["field X", "completely"])
+        self.client.index(test_index_name).add_documents([d2], tensor_fields=["field X", "completely"], auto_refresh=True)
         assert d2 == self.client.index(test_index_name).get_document("56")
 
     def test_add_batched_documents(self):
@@ -196,8 +196,7 @@ class TestAddDocuments(MarqoTestCase):
              "_id": doc_id}
             for doc_id in doc_ids]
         assert len(docs) == 100
-        ix.add_documents(docs, client_batch_size=4, tensor_fields=["Title", "Generic text"])
-        ix.refresh()
+        ix.add_documents(docs, client_batch_size=4, tensor_fields=["Title", "Generic text"], auto_refresh=True)
         time.sleep(3)
         # takes too long to search for all...
         for _id in [0, 19, 20, 99]:
@@ -218,13 +217,13 @@ class TestAddDocuments(MarqoTestCase):
             cloud_test_index_to_use=CloudTestIndex.basic_index,
             open_source_test_index_name=self.generic_test_index_name,
         )
-        self.client.index(test_index_name).add_documents([my_doc], tensor_fields=["abc"])
+        self.client.index(test_index_name).add_documents([my_doc], tensor_fields=["abc"], auto_refresh=True)
         retrieved = self.client.index(test_index_name).get_document(document_id='123')
         assert retrieved == my_doc
 
     def test_add_documents_missing_index_fails(self):
         with pytest.raises((MarqoError, MarqoWebError)) as ex:
-            self.client.index("some-non-existing-index").add_documents([{"abd": "efg"}], tensor_fields=["abc"])
+            self.client.index("some-non-existing-index").add_documents([{"abd": "efg"}], tensor_fields=["abc"], auto_refresh=True)
 
         assert ex.value.code in ["index_not_found", "index_not_found_cloud"]
 
@@ -237,7 +236,7 @@ class TestAddDocuments(MarqoTestCase):
         def run():
             temp_client.index(self.generic_test_index_name).add_documents(documents=[
                 {"d1": "blah"}, {"d2": "some data"}
-            ], device="cuda:45", tensor_fields=["d1", "d2"])
+            ], device="cuda:45", tensor_fields=["d1", "d2"], auto_refresh=True)
             return True
 
         assert run()
@@ -254,7 +253,7 @@ class TestAddDocuments(MarqoTestCase):
         def run():
             temp_client.index(self.generic_test_index_name).add_documents(documents=[
                 {"d1": "blah"}, {"d2": "some data"}, {"d2331": "blah"}, {"45d2": "some data"}
-            ], client_batch_size=2, device="cuda:37", tensor_fields=["d1", "d2", "d2331", "45d2"])
+            ], client_batch_size=2, device="cuda:37", tensor_fields=["d1", "d2", "d2331", "45d2"], auto_refresh=True)
             return True
 
         assert run()
@@ -425,7 +424,7 @@ class TestAddDocuments(MarqoTestCase):
         d1 = {"d1": "blah", "_id": "1234"}
         d2 = {"d2": "blah", "_id": "5678"}
         docs = [d1, {"content": "some terrible doc", "d3": "blah", "_id": 12345}, d2]
-        self.client.index(test_index_name).add_documents(documents=docs, tensor_fields=["d1", "d2", "d3", "content"])
+        self.client.index(test_index_name).add_documents(documents=docs, tensor_fields=["d1", "d2", "d3", "content"], auto_refresh=True)
 
         if self.IS_MULTI_INSTANCE:
             time.sleep(1)
@@ -487,7 +486,7 @@ class TestAddDocuments(MarqoTestCase):
             cloud_test_index_to_use=CloudTestIndex.basic_index,
             open_source_test_index_name=self.generic_test_index_name,
         )
-        self.client.index(test_index_name).add_documents(documents=[original_doc], non_tensor_fields=['my list'])
+        self.client.index(test_index_name).add_documents(documents=[original_doc], non_tensor_fields=['my list'], auto_refresh=True)
 
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.index(test_index_name).search,
@@ -522,7 +521,7 @@ class TestAddDocuments(MarqoTestCase):
                     "desc 2": "content 2. blah blah blah",
                     "old": "some other cool thing"
                 }],
-            non_tensor_fields=["desc 2"]
+            non_tensor_fields=["desc 2"], auto_refresh=True
         )
 
         assert {"title 1", "_embedding", "old"} == functools.reduce(
@@ -539,7 +538,7 @@ class TestAddDocuments(MarqoTestCase):
                     "title 1": "content 1",
                     "desc 2": "content 2. blah blah blah",
                     "new f": "12345 "
-                }], use_existing_tensors=True, tensor_fields=["desc 2", "new f", "title 1"]
+                }], use_existing_tensors=True, tensor_fields=["desc 2", "new f", "title 1"], auto_refresh=True
         )
         # we don't get desc 2 facets, because it was already a non_tensor_field
         assert {"title 1", "_embedding", "new f"} == functools.reduce(
@@ -664,7 +663,7 @@ class TestAddDocuments(MarqoTestCase):
                 cloud_test_index_to_use=CloudTestIndex.basic_index,
                 open_source_test_index_name=self.generic_test_index_name,
             )
-            self.client.index(test_index_name).add_documents(documents=documents, non_tensor_fields=non_tensor_fields)
+            self.client.index(test_index_name).add_documents(documents=documents, non_tensor_fields=non_tensor_fields, auto_refresh=True)
             self.assertTrue({'`non_tensor_fields`', 'Marqo', '2.0.0.'}.issubset(set(cm.output[0].split(" "))))
 
     def test_add_empty_docs(self):
@@ -674,7 +673,7 @@ class TestAddDocuments(MarqoTestCase):
         )
 
         try:
-            res = self.client.index(test_index_name).add_documents(documents=[], tensor_fields=["field a"])
+            res = self.client.index(test_index_name).add_documents(documents=[], tensor_fields=["field a"], auto_refresh=True)
             raise AssertionError
         except MarqoWebError as e:
             assert e.code == "bad_request"
@@ -686,5 +685,5 @@ class TestAddDocuments(MarqoTestCase):
             open_source_test_index_name=self.generic_test_index_name,
         )
 
-        res = self.client.index(test_index_name).add_documents(documents=[], client_batch_size=5, tensor_fields="field a")
+        res = self.client.index(test_index_name).add_documents(documents=[], client_batch_size=5, tensor_fields="field a", auto_refresh=True)
         assert res == []

--- a/tests/v0_tests/test_boost_search.py
+++ b/tests/v0_tests/test_boost_search.py
@@ -23,7 +23,8 @@ class TestBoostSearch(MarqoTestCase):
                     "_id": "d2"
                 }
             ],
-            tensor_fields=["Title", "Description"]
+            tensor_fields=["Title", "Description"],
+            auto_refresh=True
         )
 
         self.query = "What are the best pets"

--- a/tests/v0_tests/test_bulk_search.py
+++ b/tests/v0_tests/test_bulk_search.py
@@ -201,7 +201,7 @@ class TestBulkSearch(MarqoTestCase):
             cloud_test_index_to_use=CloudTestIndex.basic_index,
             open_source_test_index_name=self.generic_test_index_name,
         )
-        self.client.index(index_name=test_index_name).add_documents([{"f1": "some doc"}], tensor_fields=["f1"])
+        self.client.index(index_name=test_index_name).add_documents([{"f1": "some doc"}], tensor_fields=["f1"], auto_refresh=True)
         for params, expected_highlights_presence in [
                 ({}, True),
                 ({"showHighlights": False}, False),
@@ -351,7 +351,7 @@ class TestBulkSearch(MarqoTestCase):
                 "int_for_filtering": 1,
             }
         ]
-        res = self.client.index(test_index_name).add_documents(docs,auto_refresh=True, tensor_fields=["field_a", "field_b"])
+        res = self.client.index(test_index_name).add_documents(docs, auto_refresh=True, tensor_fields=["field_a", "field_b"])
 
         test_cases = (
             {   # filter string only (str)
@@ -704,8 +704,8 @@ class TestBulkSearch(MarqoTestCase):
             "_id": "123456"
         }
 
-        self.client.index(self.generic_test_index_name).add_documents([d1], tensor_fields=["doc title"])
-        self.client.index(self.generic_test_index_name_2).add_documents([d2], tensor_fields=["doc title"])
+        self.client.index(self.generic_test_index_name).add_documents([d1], tensor_fields=["doc title"], auto_refresh=True)
+        self.client.index(self.generic_test_index_name_2).add_documents([d2], tensor_fields=["doc title"], auto_refresh=True)
 
         for search_method in [enums.SearchMethods.TENSOR, enums.SearchMethods.LEXICAL]:
             resp = self.client.bulk_search([{
@@ -751,8 +751,8 @@ class TestBulkSearch(MarqoTestCase):
             "_id": "123456"
         }
 
-        self.client.index(test_index_name_1).add_documents([d1], tensor_fields=["doc title"])
-        self.client.index(test_index_name_2).add_documents([d2], tensor_fields=["doc title"])
+        self.client.index(test_index_name_1).add_documents([d1], tensor_fields=["doc title"], auto_refresh=True)
+        self.client.index(test_index_name_2).add_documents([d2], tensor_fields=["doc title"], auto_refresh=True)
 
         for search_method in [enums.SearchMethods.TENSOR]:
             with self.assertRaises(InvalidArgError):

--- a/tests/v0_tests/test_cloud_integration_tests.py
+++ b/tests/v0_tests/test_cloud_integration_tests.py
@@ -22,7 +22,7 @@ class TestCloudIntegrationTests(MarqoTestCase):
                 cloud_test_index_to_use=CloudTestIndex.basic_index,
                 open_source_test_index_name=self.generic_test_index_name,
             )
-            res = self.client.index(test_index_name).add_documents(documents=[{"some": "data"}], tensor_fields=["some"])
+            res = self.client.index(test_index_name).add_documents(documents=[{"some": "data"}], tensor_fields=["some"], auto_refresh=True)
             assert res == {"success": True}
             mock_documents.assert_called_once()
 
@@ -62,7 +62,7 @@ class TestCloudIntegrationTests(MarqoTestCase):
                 assert "lost" not in self.index_to_documents_cleanup_mapping.get(test_index_name)
 
             add_documents_response = self.client.index(test_index_name).add_documents(
-                documents=[{"some": "data", "_id": "lost"}], tensor_fields=["some"]
+                documents=[{"some": "data", "_id": "lost"}], tensor_fields=["some"], auto_refresh=True
             )
 
             assert add_documents_response["specific-test-key"] == 123

--- a/tests/v0_tests/test_custom_vector_search.py
+++ b/tests/v0_tests/test_custom_vector_search.py
@@ -26,7 +26,7 @@ class TestCustomVectorSearch(MarqoTestCase):
                     "Description": "A history of household pets",
                     "_id": "d2"
                 }
-            ], tensor_fields=["Title", "Description"]
+            ], tensor_fields=["Title", "Description"], auto_refresh=True
         )
         self.vector_dim = 512
 

--- a/tests/v0_tests/test_delete_documents.py
+++ b/tests/v0_tests/test_delete_documents.py
@@ -24,7 +24,7 @@ class TestDeleteDocuments(MarqoTestCase):
         self.client.index(test_index_name).add_documents([
             {"abc": "wow camel", "_id": "123"},
             {"abc": "camels are cool", "_id": "foo"}
-        ], tensor_fields=["abc"])
+        ], tensor_fields=["abc"], auto_refresh=True)
 
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.index(test_index_name).search, "wow camel")
@@ -32,7 +32,7 @@ class TestDeleteDocuments(MarqoTestCase):
         res0 = self.client.index(test_index_name).search("wow camel")
         assert res0['hits'][0]["_id"] == "123"
         assert len(res0['hits']) == 2
-        self.client.index(test_index_name).delete_documents(["123"])
+        self.client.index(test_index_name).delete_documents(["123"], auto_refresh=True)
 
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.index(test_index_name).search, "wow camel")
@@ -52,7 +52,7 @@ class TestDeleteDocuments(MarqoTestCase):
         @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
         def run():
             temp_client.index(self.generic_test_index_name).delete_documents(
-                ids=['0', '1', '2'], 
+                ids=['0', '1', '2']
             )
             return True
 
@@ -96,7 +96,7 @@ class TestDeleteDocuments(MarqoTestCase):
             cloud_test_index_to_use=CloudTestIndex.basic_index,
             open_source_test_index_name=self.generic_test_index_name,
         )
-        self.client.index(test_index_name).add_documents([{"abc": "efg", "_id": "123"}], tensor_fields=["abc"])
+        self.client.index(test_index_name).add_documents([{"abc": "efg", "_id": "123"}], tensor_fields=["abc"], auto_refresh=True)
         try:
             self.client.index(test_index_name).delete_documents([])
             raise AssertionError

--- a/tests/v0_tests/test_demos.py
+++ b/tests/v0_tests/test_demos.py
@@ -30,7 +30,7 @@ class TestDemo(MarqoTestCase):
                 S2Search is based in Melbourne. Melbourne has beautiful waterways running through it.
                 """
             },
-        ], tensor_fields=["Title", "Description", "Key Points"])
+        ], tensor_fields=["Title", "Description", "Key Points"], auto_refresh=True)
         print("\nSearching the phrase 'River' across all fields")
         
         if self.IS_MULTI_INSTANCE:
@@ -70,7 +70,7 @@ class TestDemo(MarqoTestCase):
                     "_id": "article_591"
                 }
             ],
-            tensor_fields=["Title", "Description"]
+            tensor_fields=["Title", "Description"], auto_refresh=True
         )
 
         if self.IS_MULTI_INSTANCE:
@@ -110,7 +110,7 @@ class TestDemo(MarqoTestCase):
         r5 = mq.index(test_index_name).search('adventure', searchable_attributes=['Title'])
         assert len(r5["hits"]) == 2
 
-        r6 = mq.index(test_index_name).delete_documents(ids=["article_591", "article_602"])
+        r6 = mq.index(test_index_name).delete_documents(ids=["article_591", "article_602"], auto_refresh=True)
         assert r6['details']['deletedDocuments'] == 1
 
         if not self.client.config.is_marqo_cloud:
@@ -143,7 +143,7 @@ class TestDemo(MarqoTestCase):
                     "The last known of its species died in 1936.",
                 },
             ],
-            tensor_fields=["Title", "Description"]
+            tensor_fields=["Title", "Description"], auto_refresh=True
         )
 
         r1 = mq.index(test_index_name).get_stats()
@@ -239,7 +239,7 @@ class TestDemo(MarqoTestCase):
                     },
                 }
             },
-            tensor_fields=["captioned_image"],
+            tensor_fields=["captioned_image"], auto_refresh=True
         )
 
         r1 = mq.index(test_index_name).get_stats()

--- a/tests/v0_tests/test_get_indexes.py
+++ b/tests/v0_tests/test_get_indexes.py
@@ -68,7 +68,7 @@ class TestGetIndexes(MarqoTestCase):
             raise AssertionError
 
         assert my_ix.get_stats()['numberOfDocuments'] == 0
-        my_ix.add_documents([{'some doc': 'gold fish'}], tensor_fields=['some doc'])
+        my_ix.add_documents([{'some doc': 'gold fish'}], tensor_fields=['some doc'], auto_refresh=True)
 
         if self.IS_MULTI_INSTANCE:
             time.sleep(1)

--- a/tests/v0_tests/test_image_chunking.py
+++ b/tests/v0_tests/test_image_chunking.py
@@ -40,7 +40,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (aking to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(test_index_name).add_documents([document1], tensor_fields=['location', 'description', 'attributes'])
+        client.index(test_index_name).add_documents([document1], tensor_fields=['location', 'description', 'attributes'], auto_refresh=True)
 
         # test the search works
         if self.IS_MULTI_INSTANCE:
@@ -91,7 +91,7 @@ class TestImageChunking(MarqoTestCase):
             'description': 'the image chunking can (optionally) chunk the image into sub-patches (akin to segmenting text) by using either a learned model or simple box generation and cropping',
             'location': temp_file_name}
 
-        client.index(test_index_name).add_documents([document1], tensor_fields=['location', 'description', 'attributes'])
+        client.index(test_index_name).add_documents([document1], tensor_fields=['location', 'description', 'attributes'], auto_refresh=True)
 
         # test the search works
         if self.IS_MULTI_INSTANCE:

--- a/tests/v0_tests/test_index.py
+++ b/tests/v0_tests/test_index.py
@@ -69,7 +69,7 @@ class TestIndex(MarqoTestCase):
         }
         self.client.index(test_index_name).add_documents([
             d1, d2
-        ], tensor_fields=["Blurb", "Title"])
+        ], tensor_fields=["Blurb", "Title"], auto_refresh=True)
         res = self.client.index(test_index_name).get_documents(
             ["article_152", "article_490", "article_985"]
         )
@@ -103,7 +103,7 @@ class TestIndex(MarqoTestCase):
         }
         self.client.index(test_index_name).add_documents([
             d1, d2
-        ], tensor_fields=["Blurb", "Title"])
+        ], tensor_fields=["Blurb", "Title"], auto_refresh=True)
         res = self.client.index(test_index_name).get_documents(
             ["article_152", "article_490", "article_985"],
             expose_facets=True
@@ -135,7 +135,7 @@ class TestIndex(MarqoTestCase):
         }
         self.client.index(test_index_name).add_documents([
             d1
-        ], tensor_fields=["Blurb", "Title"])
+        ], tensor_fields=["Blurb", "Title"], auto_refresh=True)
         doc_res = self.client.index(test_index_name).get_document(
             document_id="article_152",
             expose_facets=True

--- a/tests/v0_tests/test_logging.py
+++ b/tests/v0_tests/test_logging.py
@@ -44,7 +44,7 @@ class TestLogging(MarqoTestCase):
         test_index_name = self._create_img_index(index_name=self.generic_test_index_name)
         with self.assertLogs('marqo', level='INFO') as cm:
             self.client.index(index_name=test_index_name).add_documents(self._get_docs_to_index(), device="cpu",
-                                                                          tensor_fields=["Title"])
+                                                                          tensor_fields=["Title"], auto_refresh=True)
             assert len(cm.output) == 1
             assert "errors detected" in cm.output[0].lower()
             assert "info" in cm.output[0].lower()
@@ -62,7 +62,7 @@ class TestLogging(MarqoTestCase):
 
             with self.assertLogs('marqo', level='INFO') as cm:
                 self.client.index(index_name=test_index_name).add_documents(
-                    documents=self._get_docs_to_index(), device="cpu", **params, tensor_fields=["Title"])
+                    documents=self._get_docs_to_index(), device="cpu", **params, tensor_fields=["Title"], auto_refresh=True)
                 print(params, expected)
                 assert len(cm.output) == expected['num_log_msgs']
                 error_messages = [msg.lower() for msg in cm.output if "errors detected" in msg.lower()]

--- a/tests/v0_tests/test_model_auth.py
+++ b/tests/v0_tests/test_model_auth.py
@@ -14,7 +14,7 @@ class TestAddDocumentsModelAuth(MarqoTestCase):
             mock_s3_model_auth = {'s3': {'aws_access_key_id': 'some_acc_key',
                                          'aws_secret_access_key': 'some_sec_acc_key'}}
             self.client.index(index_name=self.generic_test_index_name).add_documents(
-                documents=[{"some": "data"}], model_auth=mock_s3_model_auth, tensor_fields=["some"])
+                documents=[{"some": "data"}], model_auth=mock_s3_model_auth, tensor_fields=["some"], auto_refresh=True)
             args, kwargs = mock__post.call_args
             assert "modelAuth" in kwargs['body']
             assert kwargs['body']['modelAuth'] == mock_s3_model_auth

--- a/tests/v0_tests/test_model_cache_management.py
+++ b/tests/v0_tests/test_model_cache_management.py
@@ -94,7 +94,7 @@ class TestModelCacheManagement(MarqoTestCase):
             "doc title": "Cool Document 1",
             "field 1": "some extra info"
         }
-        self.client.index(test_index_name).add_documents([d1], device="cpu", tensor_fields=["doc title", "field 1"])
+        self.client.index(test_index_name).add_documents([d1], device="cpu", tensor_fields=["doc title", "field 1"], auto_refresh=True)
         res = self.client.index(test_index_name).eject_model(self.MODEL, "cpu")
         assert res["result"] == "success"
         assert res["message"].startswith("successfully eject")

--- a/tests/v0_tests/test_score_modifier_search.py
+++ b/tests/v0_tests/test_score_modifier_search.py
@@ -32,6 +32,7 @@ class TestScoreModifierSearch(MarqoTestCase):
                  },
             ], non_tensor_fields=["multiply_1", "multiply_2", "add_1", "add_2",
                                                        "filter"]
+            , auto_refresh=True
         )
         self.query = "what is the rider doing?"
     

--- a/tests/v0_tests/test_sentence_chunking.py
+++ b/tests/v0_tests/test_sentence_chunking.py
@@ -28,7 +28,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(test_index_name).add_documents([document1], tensor_fields=['attributes', 'description', 'misc'])
+        client.index(test_index_name).add_documents([document1], tensor_fields=['attributes', 'description', 'misc'], auto_refresh=True)
 
         # test the search works
         if self.IS_MULTI_INSTANCE:
@@ -62,7 +62,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(test_index_name).add_documents([document1], tensor_fields=['attributes', 'description', 'misc'])
+        client.index(test_index_name).add_documents([document1], tensor_fields=['attributes', 'description', 'misc'], auto_refresh=True)
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'
@@ -125,7 +125,7 @@ class TestSentenceChunking(MarqoTestCase):
             'description': 'the image chunking. can (optionally) chunk. the image into sub-patches (aking to segmenting text). by using either. a learned model. or simple box generation and cropping.',
             'misc':'sasasasaifjfnonfqeno asadsdljknjdfln'}
 
-        client.index(test_index_name).add_documents([document1], tensor_fields=['attributes', 'description', 'misc'])
+        client.index(test_index_name).add_documents([document1], tensor_fields=['attributes', 'description', 'misc'], auto_refresh=True)
 
         # search with a term we know is an exact chunk and will then show in the highlights
         search_term = 'hello. how are you.'

--- a/tests/v0_tests/test_telemetry.py
+++ b/tests/v0_tests/test_telemetry.py
@@ -52,7 +52,7 @@ class TestTelemetry(MarqoTestCase):
             cloud_test_index_to_use=CloudTestIndex.basic_index,
             open_source_test_index_name=self.generic_test_index_name,
         )
-        self.client.index(test_index_name).add_documents([{"Title": "A dummy document",}], tensor_fields=["Title"])
+        self.client.index(test_index_name).add_documents([{"Title": "A dummy document",}], tensor_fields=["Title"], auto_refresh=True)
 
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.index(test_index_name).search, **search_kwargs_list[0])
@@ -67,7 +67,7 @@ class TestTelemetry(MarqoTestCase):
             cloud_test_index_to_use=CloudTestIndex.basic_index,
             open_source_test_index_name=self.generic_test_index_name,
         )
-        self.client.index(test_index_name).add_documents([{"Title": "A dummy document",}], tensor_fields=["Title"])
+        self.client.index(test_index_name).add_documents([{"Title": "A dummy document",}], tensor_fields=["Title"], auto_refresh=True)
         bulk_search_query = [
             {
                 "index": test_index_name,
@@ -105,7 +105,7 @@ class TestTelemetry(MarqoTestCase):
             open_source_test_index_name=self.generic_test_index_name,
         )
         self.client.index(test_index_name).add_documents([{"_id": "123321", "Title": "Marqo is useful",}],
-                                                           tensor_fields=["Title"])
+                                                           tensor_fields=["Title"], auto_refresh=True)
         res = self.client.index(test_index_name).get_document("123321")
         self.assertIn("telemetry", res)
         self.assertEqual(res["telemetry"], dict())
@@ -116,8 +116,8 @@ class TestTelemetry(MarqoTestCase):
             open_source_test_index_name=self.generic_test_index_name,
         )
         self.client.index(test_index_name).add_documents([{"_id": "123321", "Title": "Marqo is useful",}],
-                                                           tensor_fields=["Title"])
-        res = self.client.index(test_index_name).delete_documents(["123321"])
+                                                           tensor_fields=["Title"], auto_refresh=True)
+        res = self.client.index(test_index_name).delete_documents(["123321"], auto_refresh=True)
         self.assertIn("telemetry", res)
         self.assertEqual(res["telemetry"], dict())
 

--- a/tests/v0_tests/test_tensor_search.py
+++ b/tests/v0_tests/test_tensor_search.py
@@ -37,7 +37,7 @@ class TestSearch(MarqoTestCase):
             The editor-in-chief Katharine Viner succeeded Alan Rusbridger in 2015.[10][11] Since 2018, the paper's main newsprint sections have been published in tabloid format. As of July 2021, its print edition had a daily circulation of 105,134.[4] The newspaper has an online edition, TheGuardian.com, as well as two international websites, Guardian Australia (founded in 2013) and Guardian US (founded in 2011). The paper's readership is generally on the mainstream left of British political opinion,[12][13][14][15] and the term "Guardian reader" is used to imply a stereotype of liberal, left-wing or "politically correct" views.[3] Frequent typographical errors during the age of manual typesetting led Private Eye magazine to dub the paper the "Grauniad" in the 1960s, a nickname still used occasionally by the editors for self-mockery.[16]
             """
         }
-        add_doc_res = self.client.index(test_index_name).add_documents([d1], tensor_fields=["Title", "Description"])
+        add_doc_res = self.client.index(test_index_name).add_documents([d1], tensor_fields=["Title", "Description"], auto_refresh=True)
         
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.index(test_index_name).search,
@@ -70,7 +70,7 @@ class TestSearch(MarqoTestCase):
             cloud_test_index_to_use=CloudTestIndex.basic_index,
             open_source_test_index_name=self.generic_test_index_name,
         )
-        self.client.index(index_name=test_index_name).add_documents([{"f1": "some doc"}], tensor_fields=["f1"])
+        self.client.index(index_name=test_index_name).add_documents([{"f1": "some doc"}], tensor_fields=["f1"], auto_refresh=True)
         for params, expected_highlights_presence in [
                 ({"highlights": True, "show_highlights": False}, False),
                 ({"highlights": False, "show_highlights": True}, False),
@@ -107,7 +107,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(test_index_name).add_documents([
             d1, d2
-        ], tensor_fields=["doc title", "field X"])
+        ], tensor_fields=["doc title", "field X"], auto_refresh=True)
 
         if self.IS_MULTI_INSTANCE:
             self.warm_request(self.client.index(test_index_name).search,
@@ -136,7 +136,7 @@ class TestSearch(MarqoTestCase):
         }
         res = self.client.index(test_index_name).add_documents([
             d1, d2
-        ], tensor_fields=['doc title', 'field X'])
+        ], tensor_fields=['doc title', 'field X'], auto_refresh=True)
 
         # Ensure that vector search works
         if self.IS_MULTI_INSTANCE:
@@ -225,7 +225,7 @@ class TestSearch(MarqoTestCase):
                 "int_for_filtering": 1,
             }
         ]
-        res = self.client.index(test_index_name).add_documents(docs,auto_refresh=True, tensor_fields=["field_a", "field_b"])
+        res = self.client.index(test_index_name).add_documents(docs, auto_refresh=True, tensor_fields=["field_a", "field_b"])
 
         test_cases = (
             {   # filter string only (str)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
add docs and delete docs tests with get or search sporadically fail, since auto_refresh has been set to False by default. This is caused by Marqo release 1.4.0

* **What is the new behavior (if this is a feature change)?**
- `auto_refresh=True` added to relevant add docs and delete docs calls
- bumps Marqo version to 1.4.0

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Just tests

* **Other information**:

