### PR TITLE
Add prefix parameters to add docs and search

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="2.0.0",
+    version="2.1.0",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/src/marqo/models/search_models.py
+++ b/src/marqo/models/search_models.py
@@ -23,6 +23,7 @@ class SearchBody(BaseMarqoModel):
     context: Optional[Dict] = None
     scoreModifiers: Optional[Dict] = None
     modelAuth: Optional[Dict] = None
+    testQueryPrefix: Optional[str] = None
 
 
 class BulkSearchBody(SearchBody):

--- a/src/marqo/models/search_models.py
+++ b/src/marqo/models/search_models.py
@@ -23,7 +23,7 @@ class SearchBody(BaseMarqoModel):
     context: Optional[Dict] = None
     scoreModifiers: Optional[Dict] = None
     modelAuth: Optional[Dict] = None
-    testQueryPrefix: Optional[str] = None
+    textQueryPrefix: Optional[str] = None
 
 
 class BulkSearchBody(SearchBody):

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__marqo_version__ = "1.4.0"
+__marqo_version__ = "1.5.0"
 __marqo_release_page__ = f"https://github.com/marqo-ai/marqo/releases/tag/{__marqo_version__}"
 
 __minimum_supported_marqo_version__ = "1.0.0"

--- a/tests/cloud_test_logic/cloud_test_index.py
+++ b/tests/cloud_test_logic/cloud_test_index.py
@@ -67,4 +67,7 @@ index_name_to_settings_mappings = {
     #     },
     #     "inference_type": "marqo.CPU.large", "storage_class": "marqo.basic",
     # }
+
+    # TODO: Index using model with prefix (maybe E5)
+    # TODO: Index using text_preprocessing override
 }

--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -191,6 +191,7 @@ class MarqoTestCase(TestCase):
         cls.index_to_documents_cleanup_mapping = {}
         cls.generic_test_index_name = 'test-index'  # used as a prefix when index is created with settings
         cls.generic_test_index_name_2 = cls.generic_test_index_name + '-2'
+        cls.generic_test_index_name_3 = cls.generic_test_index_name + '-3'
 
         # class property to indicate if test is being run on multi
         cls.IS_MULTI_INSTANCE = (True if os.environ.get("IS_MULTI_INSTANCE", False) in ["True", "TRUE", "true", True] else False)

--- a/tests/v0_tests/test_bulk_search.py
+++ b/tests/v0_tests/test_bulk_search.py
@@ -61,7 +61,8 @@ class TestBulkSearch(MarqoTestCase):
                         },
                         "scoreModifiers": None,
                         "modelAuth": None,
-                        "index": "test-index"
+                        "index": "test-index",
+                        "textQueryPrefix": None
                     }
                 ]
             }
@@ -113,7 +114,8 @@ class TestBulkSearch(MarqoTestCase):
                             ]
                         },
                         "modelAuth": None,
-                        "index": "test-index"
+                        "index": "test-index",
+                        "textQueryPrefix": None
                     }
                 ]
             }

--- a/tests/v0_tests/test_prefix.py
+++ b/tests/v0_tests/test_prefix.py
@@ -1,0 +1,182 @@
+import copy
+import functools
+import math
+import pprint
+import random
+import pytest
+import requests
+import time
+
+from pytest import mark
+
+from marqo.errors import MarqoError, MarqoWebError
+from tests.marqo_test import MarqoTestCase, CloudTestIndex
+from marqo import enums
+from unittest import mock
+import numpy as np
+
+
+@mark.ignore_during_cloud_tests
+class TestChunkPrefix(MarqoTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_index_with_model_default_prefix = self.create_test_index(
+            cloud_test_index_to_use=CloudTestIndex.basic_index,
+            open_source_test_index_name=self.generic_test_index_name,
+            open_source_index_settings_dict={
+                "index_defaults": {
+                    "model": "prefix-test-model"    # Loads sentence-transformers/all-MiniLM-L6-v1. uses "test query: " and "test passage: "
+                }
+            }
+        )
+        self.test_index_with_index_override_prefix = self.create_test_index(
+            cloud_test_index_to_use=CloudTestIndex.basic_index,
+            open_source_test_index_name=self.generic_test_index_name_3,
+            open_source_index_settings_dict={
+                "index_defaults": {
+                    "model": "prefix-test-model",    # Loads sentence-transformers/all-MiniLM-L6-v1. No default prefix
+                    "text_preprocessing": {
+                        "override_text_chunk_prefix": "override passage: ",
+                    }
+                }
+            }
+        )
+        self.test_index_with_no_prefix = self.create_test_index(
+            cloud_test_index_to_use=CloudTestIndex.basic_index,
+            open_source_test_index_name=self.generic_test_index_name_2,
+            open_source_index_settings_dict={
+                "index_defaults": {
+                    "model": "sentence-transformers/test"    # Loads sentence-transformers/all-MiniLM-L6-v1. No default prefix
+                }
+            }
+        )
+
+
+    def test_chunk_prefix_use_model_default(self):
+        # Doc A should have prefix from model default, Doc B should have prefix from built in text
+        self.client.index(self.test_index_with_model_default_prefix).add_documents(
+            documents=[{"_id": "doc_a", "text": "HELLO"}], 
+            auto_refresh=True, tensor_fields=["text"]
+        )
+        self.client.index(self.test_index_with_no_prefix).add_documents(
+            documents=[{"_id": "doc_b", "text": "test passage: HELLO"}], 
+            auto_refresh=True, tensor_fields=["text"]
+        )
+
+        retrieved_doc_a = self.client.index(self.test_index_with_model_default_prefix).get_document(document_id="doc_a", expose_facets=True)
+        retrieved_doc_b = self.client.index(self.test_index_with_no_prefix).get_document(document_id="doc_b", expose_facets=True)
+        assert np.allclose(retrieved_doc_a["_tensor_facets"][0]["_embedding"], retrieved_doc_b["_tensor_facets"][0]["_embedding"], atol=1e-5)
+
+
+    def test_chunk_prefix_use_index_override(self):
+        # Doc A should have prefix from index override, Doc B should have prefix from built in text
+        self.client.index(self.test_index_with_index_override_prefix).add_documents(
+            documents=[{"_id": "doc_a", "text": "HELLO"}], 
+            auto_refresh=True, tensor_fields=["text"]
+        )
+        self.client.index(self.test_index_with_no_prefix).add_documents(
+            documents=[{"_id": "doc_b", "text": "override passage: HELLO"}], 
+            auto_refresh=True, tensor_fields=["text"]
+        )
+
+        retrieved_doc_a = self.client.index(self.test_index_with_index_override_prefix).get_document(document_id="doc_a", expose_facets=True)
+        retrieved_doc_b = self.client.index(self.test_index_with_no_prefix).get_document(document_id="doc_b", expose_facets=True)
+        assert np.allclose(retrieved_doc_a["_tensor_facets"][0]["_embedding"], retrieved_doc_b["_tensor_facets"][0]["_embedding"], atol=1e-5)
+
+
+    def test_chunk_prefix_use_add_docs_override(self):
+        # Doc A should have prefix from add docs override, Doc B should have prefix from built in text
+        self.client.index(self.test_index_with_index_override_prefix).add_documents(
+            documents=[{"_id": "doc_a", "text": "HELLO"}], 
+            auto_refresh=True, tensor_fields=["text"], text_chunk_prefix="add docs passage: "
+        )
+        self.client.index(self.test_index_with_no_prefix).add_documents(
+            documents=[{"_id": "doc_b", "text": "add docs passage: HELLO"}], 
+            auto_refresh=True, tensor_fields=["text"]
+        )
+
+        retrieved_doc_a = self.client.index(self.test_index_with_index_override_prefix).get_document(document_id="doc_a", expose_facets=True)
+        retrieved_doc_b = self.client.index(self.test_index_with_no_prefix).get_document(document_id="doc_b", expose_facets=True)
+        assert np.allclose(retrieved_doc_a["_tensor_facets"][0]["_embedding"], retrieved_doc_b["_tensor_facets"][0]["_embedding"], atol=1e-5)
+
+
+@mark.ignore_during_cloud_tests
+class TestQueryPrefix(MarqoTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_index_with_model_default_prefix = self.create_test_index(
+            cloud_test_index_to_use=CloudTestIndex.basic_index,
+            open_source_test_index_name=self.generic_test_index_name,
+            open_source_index_settings_dict={
+                "index_defaults": {     # Using custom model to manually define query prefix
+                    "model": "generic-clip-test-model-1",
+                    "model_properties": {
+                        "name": "ViT-B-32-quickgelu",
+                        "dimensions": 512,
+                        "url": "https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_avg-8a00ab3c.pt",
+                        "type": "open_clip",
+                        "text_query_prefix": "test query: ",
+                    }
+                }
+            }
+        )
+        self.test_index_with_index_override_prefix = self.create_test_index(
+            cloud_test_index_to_use=CloudTestIndex.basic_index,
+            open_source_test_index_name=self.generic_test_index_name_3,
+            open_source_index_settings_dict={
+                "index_defaults": {
+                    "model": "generic-clip-test-model-1",
+                    "model_properties": {
+                        "name": "ViT-B-32-quickgelu",
+                        "dimensions": 512,
+                        "url": "https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_avg-8a00ab3c.pt",
+                        "type": "open_clip",
+                        "text_query_prefix": "test query: ",
+                    },
+                    "text_preprocessing": {
+                        "override_text_query_prefix": "override query: "
+                    }
+                }
+            }
+        )
+        self.test_index_with_no_prefix = self.create_test_index(
+            cloud_test_index_to_use=CloudTestIndex.basic_index,
+            open_source_test_index_name=self.generic_test_index_name_2,
+            open_source_index_settings_dict={
+                "index_defaults": {
+                    "model": "generic-clip-test-model-1",
+                    "model_properties": {
+                        "name": "ViT-B-32-quickgelu",
+                        "dimensions": 512,
+                        "url": "https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_avg-8a00ab3c.pt",
+                        "type": "open_clip",
+                    }
+                }
+            }
+        )
+
+        # Add 4 docs to each index (for search test options)
+        for index_name in [self.test_index_with_model_default_prefix, self.test_index_with_index_override_prefix, self.test_index_with_no_prefix]:
+            self.client.index(index_name).add_documents(
+                documents=[
+                    {"_id": "doc_no_prefix", "text": "HELLO"}, 
+                    {"_id": "doc_model_default_prefix", "text": "test query: HELLO"}, 
+                    {"_id": "doc_index_override_prefix", "text": "override query: HELLO"},
+                    {"_id": "doc_search_override_prefix", "text": "search query: HELLO"}
+                ], 
+                auto_refresh=True, tensor_fields=["text"]
+            )
+    
+    def test_query_prefix_use_model_default(self):
+        res = self.client.index(self.test_index_with_model_default_prefix).search(q="HELLO", search_method="TENSOR")
+        assert res["hits"][0]["_id"] == "doc_model_default_prefix"
+
+
+    def test_query_prefix_use_index_override(self):
+        res = self.client.index(self.test_index_with_index_override_prefix).search(q="HELLO", search_method="TENSOR")
+        assert res["hits"][0]["_id"] == "doc_index_override_prefix"
+
+
+    def test_query_prefix_use_search_override(self):
+        res = self.client.index(self.test_index_with_index_override_prefix).search(q="HELLO", search_method="TENSOR", text_query_prefix="search query: ")
+        assert res["hits"][0]["_id"] == "doc_search_override_prefix"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [] Tests for the changes have been added (for bug fixes/features)
- [] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
No prefix parameters in add documents or search functions

* **What is the new behavior (if this is a feature change)?**
- `text_chunk_prefix` added to `add_documents`
- `text_query_prefix` added to `search`
- `textQueryPrefix` added to `SearchModel`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
