### PR TITLE
change int_filter_field_1 to int_field_1 in tests

### DIFF
--- a/tests/marqo_test.py
+++ b/tests/marqo_test.py
@@ -229,10 +229,7 @@ class MarqoTestCase(TestCase):
                         "allFields": [{"name": "text_field_1", "type": "text", "features": ["lexical_search", "filter"]},
                                       {"name": "text_field_2", "type": "text", "features": ["lexical_search", "filter"]},
                                       {"name": "text_field_3", "type": "text", "features": ["lexical_search"]},
-                                      {"name": "int_field_1", "type": "int", "features": ["score_modifier"]},
-                                      {"name": "int_filter_field_1", "type": "int",
-                                       "features": ["filter", "score_modifier"]
-                                       }],
+                                      {"name": "int_field_1", "type": "int", "features": ["score_modifier", "filter"]}],
                         "tensorFields": ["text_field_1", "text_field_2", "text_field_3"]
                     },
                     {

--- a/tests/v2_tests/test_tensor_search.py
+++ b/tests/v2_tests/test_tensor_search.py
@@ -224,27 +224,27 @@ class TestSearch(MarqoTestCase):
                     "_id": "0",                     # content in field_a
                     "text_field_1": "random content",
                     "text_field_2": "apple",
-                    "int_filter_field_1": 0,
+                    "int_field_1": 0,
                 },
                 {
                     "_id": "1",                     # content in field_b
                     "text_field_3": "random content",
                     "text_field_2": "banana",
-                    "int_filter_field_1": 0,
+                    "int_field_1": 0,
                 },
                 {
                     "_id": "2",                     # content in both
                     "text_field_1": "random content",
                     "text_field_3": "random content",
                     "text_field_2": "apple",
-                    "int_filter_field_1": 1,
+                    "int_field_1": 1,
                 },
                 {
                     "_id": "3",                     # content in both
                     "text_field_1": "random content",
                     "text_field_3": "random content",
                     "text_field_2": "banana",
-                    "int_filter_field_1": 1,
+                    "int_field_1": 1,
                 }
             ]
             res = self.client.index(test_index_name).add_documents(docs)
@@ -259,25 +259,25 @@ class TestSearch(MarqoTestCase):
                 },
                 {   # filter string only (int)
                     "query": "random content",
-                    "filter_string": "int_filter_field_1:(0)",
+                    "filter_string": "int_field_1:(0)",
                     "searchable_attributes": None,
                     "expected": ["0", "1"]
                 },
                 {   # filter string only (str and int)
                     "query": "random content",
-                    "filter_string": "text_field_2:(banana) AND int_filter_field_1:(1)",
+                    "filter_string": "text_field_2:(banana) AND int_field_1:(1)",
                     "searchable_attributes": None,
                     "expected": ["3"]
                 },
                 {  # filter string only (IN with AND)
                     "query": "random content",
-                    "filter_string": "text_field_2 in (banana, orange) AND int_filter_field_1 in (0, 1)",
+                    "filter_string": "text_field_2 in (banana, orange) AND int_field_1 in (0, 1)",
                     "searchable_attributes": None,
                     "expected": ["1", "3"]
                 },
                 {  # filter string (IN with OR)
                     "query": "random content",
-                    "filter_string": "text_field_2 in (banana, orange) OR int_filter_field_1 in (1)",
+                    "filter_string": "text_field_2 in (banana, orange) OR int_field_1 in (1)",
                     "searchable_attributes": None,
                     "expected": ["1", "2", "3"]
                 },
@@ -307,7 +307,7 @@ class TestSearch(MarqoTestCase):
                 },
                 {   # filter string and searchable attributes (both)
                     "query": "random content",
-                    "filter_string": "text_field_2:(banana) AND int_filter_field_1:(0)",
+                    "filter_string": "text_field_2:(banana) AND int_field_1:(0)",
                     "searchable_attributes": ["text_field_1"],
                     "expected": []
                 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix in cloud only.

* **What is the current behavior?** (You can also link to an open issue here)
Open source tests work, but cloud test fails.

* **What is the new behavior (if this is a feature change)?**
Change references of int_filter_field_1 to int_field_1 in open source, to match cloud index.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

