### PR TITLE
fix inferenceType typo in cloud integ tests

### DIFF
--- a/tests/cloud_test_logic/cloud_test_index.py
+++ b/tests/cloud_test_logic/cloud_test_index.py
@@ -61,7 +61,7 @@ index_name_to_settings_mappings = {
     CloudTestIndex.structured_image: {
         "type": "structured",
         "model": "open_clip/ViT-B-32/laion2b_s34b_b79k",
-        "infereceType": "marqo.CPU.small",
+        "inferenceType": "marqo.CPU.small",
         "storageClass": "marqo.basic",
         "allFields": [
             {"name": "text_field_1", "type": "text", "features": ["lexical_search", "filter"]},

--- a/tests/cloud_test_logic/cloud_test_index.py
+++ b/tests/cloud_test_logic/cloud_test_index.py
@@ -144,7 +144,6 @@ index_name_to_settings_mappings = {
     # },
     CloudTestIndex.structured_text: {
         "type": "structured",
-        "treatUrlsAndPointersAsImages": False,
         "model": "hf/all_datasets_v4_MiniLM-L6",
         "allFields": [
             {"name": "text_field_1", "type": "text", "features": ["lexical_search", "filter"]},


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix Integ test input typo

* **What is the current behavior?** (You can also link to an open issue here)
After Cloud validation changes, typo causes error returned. Previously it passes because we have an assumed default.

* **What is the new behavior (if this is a feature change)?**
Input will be accepted

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

