### PR TITLE
add new fieldtypes for dict score modifiers

### DIFF
--- a/.github/workflows/open-source-unit-tests.yml
+++ b/.github/workflows/open-source-unit-tests.yml
@@ -2,7 +2,7 @@
 # This workflow pulls a Marqo image and runs it. Py-marqo then connects to the 
 # running container for the tests. 
 # Unless otherwise specified, the Marqo version that is used for this test will be 
-# that specified by py-marqo's `marqo.version.__marqo_version__`
+# that specified by py-marqo's `marqo.version.__tests_target_marqo_version__`
 
 name: Open source unit tests
 
@@ -80,7 +80,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           export PYTHONPATH=$(pwd):$(pwd)/src:$PYTHONPATH
-          SUPPORTED_MQ_VERSION=$(python -c 'from marqo import version; print(version.__marqo_version__)') || exit 1
+          SUPPORTED_MQ_VERSION=$(python -c 'from marqo import version; print(version.__tests_target_marqo_version__)') || exit 1
           
           # error out if version is empty:
           if [ -z "$SUPPORTED_MQ_VERSION" ]; then exit 1; fi

--- a/.github/workflows/open-source-unit-tests.yml
+++ b/.github/workflows/open-source-unit-tests.yml
@@ -2,7 +2,7 @@
 # This workflow pulls a Marqo image and runs it. Py-marqo then connects to the 
 # running container for the tests. 
 # Unless otherwise specified, the Marqo version that is used for this test will be 
-# that specified by py-marqo's `marqo.version.__tests_target_marqo_version__`
+# that specified by py-marqo's `marqo.version.__minimum_supported_marqo_version__`
 
 name: Open source unit tests
 
@@ -80,7 +80,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           export PYTHONPATH=$(pwd):$(pwd)/src:$PYTHONPATH
-          SUPPORTED_MQ_VERSION=$(python -c 'from marqo import version; print(version.__tests_target_marqo_version__)') || exit 1
+          SUPPORTED_MQ_VERSION=$(python -c 'from marqo import version; print(version.__minimum_supported_marqo_version__)') || exit 1
           
           # error out if version is empty:
           if [ -z "$SUPPORTED_MQ_VERSION" ]; then exit 1; fi

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="3.5.1",
+    version="3.5.2",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="3.5.2",
+    version="3.6.0",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/src/marqo/models/marqo_index.py
+++ b/src/marqo/models/marqo_index.py
@@ -25,6 +25,10 @@ class FieldType(str, Enum):
     ImagePointer = 'image_pointer'
     MultimodalCombination = 'multimodal_combination'
     CustomVector = "custom_vector"
+    MapInt = 'map<text, int>'
+    MapLong = 'map<text, long>'  
+    MapFloat = 'map<text, float>'
+    MapDouble = 'map<text, double>'
 
 
 class VectorNumericType(str, Enum):

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,6 +1,4 @@
-#__marqo_version__ = "2.9.0"
 __tests_target_marqo_version__ = "2.9.0"
-#__marqo_release_page__ = f"https://github.com/marqo-ai/marqo/releases/tag/{__marqo_version__}"
 
 __minimum_supported_marqo_version__ = "2.9.0"
 

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,5 +1,3 @@
-__tests_target_marqo_version__ = "2.9.0"
-
 __minimum_supported_marqo_version__ = "2.9.0"
 
 

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,13 +1,12 @@
-__marqo_version__ = "2.9.0"
-__marqo_release_page__ = f"https://github.com/marqo-ai/marqo/releases/tag/{__marqo_version__}"
+#__marqo_version__ = "2.9.0"
+__tests_target_marqo_version__ = "2.9.0"
+#__marqo_release_page__ = f"https://github.com/marqo-ai/marqo/releases/tag/{__marqo_version__}"
 
-__minimum_supported_marqo_version__ = "2.6.0"
+__minimum_supported_marqo_version__ = "2.9.0"
 
 
 def supported_marqo_version() -> str:
-    return f"This Marqo Python client is built for Marqo release ({__marqo_version__}) \n" \
-           f"{__marqo_release_page__} \n" \
-           f"The minimum supported Marqo version for this client is ({__minimum_supported_marqo_version__}) \n"
+    return f"The minimum supported Marqo version for this client is ({__minimum_supported_marqo_version__}) \n"
 
 
 def minimum_supported_marqo_version() -> str:

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,4 +1,4 @@
-__marqo_version__ = "2.8.0"
+__marqo_version__ = "2.9.0"
 __marqo_release_page__ = f"https://github.com/marqo-ai/marqo/releases/tag/{__marqo_version__}"
 
 __minimum_supported_marqo_version__ = "2.6.0"

--- a/src/marqo/version.py
+++ b/src/marqo/version.py
@@ -1,6 +1,6 @@
 __minimum_supported_marqo_version__ = "2.9.0"
 
-
+# NOTE: This isn't used anywhere
 def supported_marqo_version() -> str:
     return f"The minimum supported Marqo version for this client is ({__minimum_supported_marqo_version__}) \n"
 

--- a/tests/v2_tests/test_create_index.py
+++ b/tests/v2_tests/test_create_index.py
@@ -3,6 +3,7 @@ import uuid
 from pytest import mark
 import numpy as np
 
+from marqo.models.marqo_index import FieldType
 from marqo.errors import MarqoWebError
 from tests.marqo_test import MarqoTestCase
 
@@ -244,6 +245,27 @@ class TestCreateIndex(MarqoTestCase):
                           "dimensions": 384,
                           "tokens": 512,
                           "type": "sbert"}, index_settings['modelProperties'])
+        
+    def test_create_structured_index_with_map_fields(self):
+        self.client.create_index(
+            index_name=self.index_name,
+            type="structured",
+            model="hf/all_datasets_v4_MiniLM-L6",
+            all_fields=[{"name": "test", "type": "text", "features": ["lexical_search"]},
+                        {"name": "map_score_mod_float_1", "type": FieldType.MapFloat, "features": ["score_modifier"]},
+                        {"name": "map_score_mod_double_1", "type": FieldType.MapDouble, "features": ["score_modifier"]},
+                        {"name": "map_score_mod_int_1", "type": FieldType.MapInt, "features": ["score_modifier"]},
+                        {"name": "map_score_mod_long_1", "type": FieldType.MapLong, "features": ["score_modifier"]},],
+            tensor_fields=["test"]
+        )
+        documents = [{"test": "test"}]
+        self.client.index(self.index_name).add_documents(documents)
+
+        lexical_search_res = self.client.index(self.index_name).search(q="test", search_method="LEXICAL")
+        tensor_search_res = self.client.index(self.index_name).search(q="test", search_method="TENSOR")
+
+        self.assertEqual(1, len(lexical_search_res['hits']))
+        self.assertEqual(1, len(tensor_search_res['hits']))
 
     def test_create_structured_image_index_with_preprocessing(self):
         self.client.create_index(index_name=self.index_name,

--- a/tests/v2_tests/test_score_modifier_search.py
+++ b/tests/v2_tests/test_score_modifier_search.py
@@ -21,9 +21,9 @@ class TestScoreModifierSearch(MarqoTestCase):
                      "my_image_field": "https://marqo-assets.s3.amazonaws.com/tests/images/image2.jpg",
                      # 4 fields
                      "multiply_1": 1,
-                     "multiply_2": 20.0,
+                     "multiply_2": {"a": 20.0},
                      "add_1": 1.0,
-                     "add_2": 30.0,
+                     "add_2": {"a": 30.0},
                      "_id": "1"
                      },
                     {"my_text_field": "A rider is riding a horse jumping over the barrier.",
@@ -49,11 +49,11 @@ class TestScoreModifierSearch(MarqoTestCase):
                 "multiply_score_by":
                     [{"field_name": "multiply_1",
                       "weight": 1,},
-                     {"field_name": "multiply_2",}],
+                     {"field_name": "multiply_2.a",}],
                 "add_to_score": [
                     {"field_name": "add_1", "weight" : -3,
                      },
-                    {"field_name": "add_2", "weight": 1,
+                    {"field_name": "add_2.a", "weight": 1,
                      }]
             }
 
@@ -77,11 +77,11 @@ class TestScoreModifierSearch(MarqoTestCase):
                 "multiply_score_bys":
                     [{"field_name": "multiply_1",
                       "weight": 1,},
-                     {"field_name": "multiply_2",}],
+                     {"field_name": "multiply_2.a",}],
                 "add_to_score": [
                     {"field_name": "add_1", "weight" : 4,
                      },
-                    {"field_name": "add_2", "weight": 1,
+                    {"field_name": "add_2.a", "weight": 1,
                      }]
             }
 
@@ -97,7 +97,7 @@ class TestScoreModifierSearch(MarqoTestCase):
                 "add_to_score": [
                     {"field_name": "add_1", "weight" : -3,
                      },
-                    {"field_name": "add_2", "weight": 1,
+                    {"field_name": "add_2.a", "weight": 1,
                      }]
             }
         self.search_with_score_modifier(score_modifiers=valid_score_modifiers)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
No `FieldTypes` defined for map score modifiers

* **What is the new behavior (if this is a feature change)?**
Added 4 new map numeric fieldtypes for dictionary score modifiers. Removed superfluour `__marqo_version__` variable

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:

