### PR TITLE
Add max mem to 15

### DIFF
--- a/.github/workflows/open-source-unit-tests.yml
+++ b/.github/workflows/open-source-unit-tests.yml
@@ -116,6 +116,8 @@ jobs:
           docker pull ${{ steps.prepare.outputs.registry }}/${{ steps.prepare.outputs.image_repo }}:${{ steps.prepare.outputs.image_tag }}
           docker run --name marqo -d --privileged -p 8882:8882 --add-host host.docker.internal:host-gateway \
             -e MARQO_ENABLE_BATCH_APIS=True \
+            -e MARQO_MAX_CUDA_MODEL_MEMORY=15 \
+            -e MARQO_MAX_CPU_MODEL_MEMORY=15 \
             ${{ steps.prepare.outputs.registry }}/${{ steps.prepare.outputs.image_repo }}:${{ steps.prepare.outputs.image_tag }}
                     
           # wait for marqo to start with timeout of 10 minutes


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
we use the default -MARQO_MAX_CUDA_MODEL_MEMORY=4 and MARQO_MAX_CPU_MODEL_MEMORY=4 in the tests. This fails the tests because we want to load a model larger than 4.

* **What is the new behavior (if this is a feature change)?**
we chang them to -e MARQO_MAX_CUDA_MODEL_MEMORY=32 \
-e MARQO_MAX_CPU_MODEL_MEMORY=32 \

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:

