### PR TITLE
Unpin urllib3 (remove upper bound) to allow 2.x version to be used

### DIFF
--- a/.github/workflows/open-source-unit-tests.yml
+++ b/.github/workflows/open-source-unit-tests.yml
@@ -144,6 +144,9 @@ jobs:
 
       - name: Run Py-Marqo Tests
         run: |
+          # show all warnings to capture deprecation warnings when running tests 
+          export PYTHONWARNINGS="default"
+          
           python -m pip install --upgrade pip
           # Required for Python 3.12 and above
           pip install setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+-r requirements.txt
+pillow
+numpy
+pytest
+dataclasses
+requests_mock
+tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ urllib3>=1.26.0
 requests
 pydantic>=2.0.0
 packaging
+
+# Please note that test dependescies should be put in requirements-dev.txt file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,4 @@
-# marqo client:
-urllib3<2.0.0, >=1.26.0
+urllib3>=1.26.0
 requests
-packaging
-
-# testing
-pillow
-numpy
-pytest
-dataclasses
 pydantic>=2.0.0
-requests_mock
-tenacity
+packaging

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,11 @@ setup(
     install_requires=[
         # client:
         "requests",
-        "urllib3<2.0.0, >=1.26.0",
+        "urllib3>=1.26.0",
         "pydantic>=2.0.0",
-        "typing-extensions>=4.5.0",
         "packaging"
     ],
     tests_require=[
-        "pytest",
         "tox"
     ],
     name="marqo",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="3.9.1",
+    version="3.9.2",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,7 @@ passenv =
 whitelist_externals =
   python
 deps =
-  -r requirements.txt
-  pytest
-  pillow
-  numpy
+  -r requirements-dev.txt
 commands =
   pytest {posargs}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Dependency versioning

* **What is the current behavior?** (You can also link to an open issue here)
- urllib3 are pinned to 1.26.x version

* **What is the new behavior (if this is a feature change)?**
- urllib3 are only pinned to >=1.26.0 version

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

