### PR TITLE
Fix client test setup bug

### DIFF
--- a/tests/v2_tests/test_client.py
+++ b/tests/v2_tests/test_client.py
@@ -15,6 +15,7 @@ from marqo.marqo_cloud_instance_mappings import MarqoCloudInstanceMappings
 from marqo.default_instance_mappings import DefaultInstanceMappings
 
 
+@mark.fixed
 class TestClient(MarqoTestCase):
     def test_check_index_health_response(self):
         for cloud_test_index_to_use, open_source_test_index_name in self.test_cases:
@@ -65,9 +66,14 @@ class TestClient(MarqoTestCase):
         self.assertEqual(client.config.instance_mapping.get_control_base_url(), "https://arandomsite.ai")
 
 
+@mark.fixed
 class TestClientMethods(MarqoTestCase):
+    def setUp(self) -> None:
+        self.initial_marqo_cloud_url = os.environ.get("MARQO_CLOUD_URL", constants.CLOUD_AWS_API_ENDPOINT)
+
     def tearDown(self) -> None:
-        os.environ["MARQO_CLOUD_URL"] = constants.CLOUD_AWS_API_ENDPOINT
+        os.environ["MARQO_CLOUD_URL"] = self.initial_marqo_cloud_url
+
     def test_is_cloud_api_endpoint(self):
         # Custom Marqo Cloud URL
         os.environ["MARQO_CLOUD_URL"] = "https://arandomsite.ai"

--- a/tests/v2_tests/test_client.py
+++ b/tests/v2_tests/test_client.py
@@ -15,7 +15,6 @@ from marqo.marqo_cloud_instance_mappings import MarqoCloudInstanceMappings
 from marqo.default_instance_mappings import DefaultInstanceMappings
 
 
-@mark.fixed
 class TestClient(MarqoTestCase):
     def test_check_index_health_response(self):
         for cloud_test_index_to_use, open_source_test_index_name in self.test_cases:
@@ -66,7 +65,6 @@ class TestClient(MarqoTestCase):
         self.assertEqual(client.config.instance_mapping.get_control_base_url(), "https://arandomsite.ai")
 
 
-@mark.fixed
 class TestClientMethods(MarqoTestCase):
     def tearDown(self) -> None:
         os.environ["MARQO_CLOUD_URL"] = constants.CLOUD_AWS_API_ENDPOINT


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
client tests and all succeeding tests fail because MARQO_CLOUD_URL is set to the wrong URL in tearDown.

* **What is the new behavior (if this is a feature change)?**
Properly save existing MARQO_CLOUD_URL in setUp then returning it in tearDown.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:

