### PR TITLE
Version bump to 3.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "tox"
     ],
     name="marqo",
-    version="3.10.0",
+    version="3.11.0",
     author="marqo org",
     author_email="org@marqo.io",
     description="Tensor search for humans",

--- a/tests/v2_tests/test_client.py
+++ b/tests/v2_tests/test_client.py
@@ -18,9 +18,11 @@ from marqo.default_instance_mappings import DefaultInstanceMappings
 @mark.fixed
 class TestClient(MarqoTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.initial_marqo_cloud_url = os.environ.get("MARQO_CLOUD_URL", constants.CLOUD_AWS_API_ENDPOINT)
 
     def tearDown(self) -> None:
+        super().tearDown()
         os.environ["MARQO_CLOUD_URL"] = self.initial_marqo_cloud_url
 
     def test_check_index_health_response(self):
@@ -76,9 +78,11 @@ class TestClient(MarqoTestCase):
 @mark.fixed
 class TestClientMethods(MarqoTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.initial_marqo_cloud_url = os.environ.get("MARQO_CLOUD_URL", constants.CLOUD_AWS_API_ENDPOINT)
 
     def tearDown(self) -> None:
+        super().tearDown()
         os.environ["MARQO_CLOUD_URL"] = self.initial_marqo_cloud_url
 
     def test_is_cloud_api_endpoint(self):

--- a/tests/v2_tests/test_client.py
+++ b/tests/v2_tests/test_client.py
@@ -15,6 +15,7 @@ from marqo.marqo_cloud_instance_mappings import MarqoCloudInstanceMappings
 from marqo.default_instance_mappings import DefaultInstanceMappings
 
 
+@mark.fixed
 class TestClient(MarqoTestCase):
     def test_check_index_health_response(self):
         for cloud_test_index_to_use, open_source_test_index_name in self.test_cases:
@@ -65,9 +66,14 @@ class TestClient(MarqoTestCase):
         self.assertEqual(client.config.instance_mapping.get_control_base_url(), "https://arandomsite.ai")
 
 
+@mark.fixed
 class TestClientMethods(MarqoTestCase):
+    def setUp(self) -> None:
+        self.initial_marqo_cloud_url = os.environ.get("MARQO_CLOUD_URL", constants.CLOUD_AWS_API_ENDPOINT)
+
     def tearDown(self) -> None:
-        os.environ["MARQO_CLOUD_URL"] = constants.CLOUD_AWS_API_ENDPOINT
+        os.environ["MARQO_CLOUD_URL"] = self.initial_marqo_cloud_url
+
     def test_is_cloud_api_endpoint(self):
         # Custom Marqo Cloud URL
         os.environ["MARQO_CLOUD_URL"] = "https://arandomsite.ai"

--- a/tests/v2_tests/test_client.py
+++ b/tests/v2_tests/test_client.py
@@ -15,7 +15,6 @@ from marqo.marqo_cloud_instance_mappings import MarqoCloudInstanceMappings
 from marqo.default_instance_mappings import DefaultInstanceMappings
 
 
-@mark.fixed
 class TestClient(MarqoTestCase):
     def test_check_index_health_response(self):
         for cloud_test_index_to_use, open_source_test_index_name in self.test_cases:
@@ -66,7 +65,6 @@ class TestClient(MarqoTestCase):
         self.assertEqual(client.config.instance_mapping.get_control_base_url(), "https://arandomsite.ai")
 
 
-@mark.fixed
 class TestClientMethods(MarqoTestCase):
     def tearDown(self) -> None:
         os.environ["MARQO_CLOUD_URL"] = constants.CLOUD_AWS_API_ENDPOINT

--- a/tests/v2_tests/test_client.py
+++ b/tests/v2_tests/test_client.py
@@ -17,6 +17,12 @@ from marqo.default_instance_mappings import DefaultInstanceMappings
 
 @mark.fixed
 class TestClient(MarqoTestCase):
+    def setUp(self) -> None:
+        self.initial_marqo_cloud_url = os.environ.get("MARQO_CLOUD_URL", constants.CLOUD_AWS_API_ENDPOINT)
+
+    def tearDown(self) -> None:
+        os.environ["MARQO_CLOUD_URL"] = self.initial_marqo_cloud_url
+
     def test_check_index_health_response(self):
         for cloud_test_index_to_use, open_source_test_index_name in self.test_cases:
             test_index_name = self.get_test_index_name(
@@ -39,17 +45,16 @@ class TestClient(MarqoTestCase):
                 self.assertIn(f"health", kwargs["path"])
 
     def test_overwrite_cloud_url_and_client_is_set_to_marqo(self):
-        current = os.environ.get("MARQO_CLOUD_URL", constants.CLOUD_AWS_API_ENDPOINT)
         os.environ["MARQO_CLOUD_URL"] = "https://cloud.url.com"
         client = Client(url="https://cloud.url.com", api_key="test")
         self.assertTrue(client.config.is_marqo_cloud)
-        os.environ["MARQO_CLOUD_URL"] = current
 
     def test_default_cloud_endpoint_client_is_marqo_cloud(self):
         """
-        Checks that if a client is created with one of the 2 cloud URLs (AWS or GCP),
+        Checks that if MARQO_CLOUD_URL is not set and a client is created with one of the 2 cloud URLs (AWS or GCP),
         the client is set to Marqo Cloud.
         """
+        del os.environ["MARQO_CLOUD_URL"]
         for cloud_url in constants.CLOUD_API_ENDPOINTS:
             client = Client(url=cloud_url)
             self.assertTrue(client.config.is_marqo_cloud)
@@ -58,8 +63,10 @@ class TestClient(MarqoTestCase):
 
     def test_non_cloud_endpoint_client_is_not_marqo_cloud(self):
         """
-        Checks that if a client is created with a non-cloud URL, the client is not set to Marqo Cloud.
+        Checks that if MARQO_CLOUD_URL is not set and a client is created with a non-cloud URL,
+        the client is not set to Marqo Cloud.
         """
+        del os.environ["MARQO_CLOUD_URL"]
         client = Client(url="https://arandomsite.ai")
         self.assertFalse(client.config.is_marqo_cloud)
         self.assertIsInstance(client.config.instance_mapping, DefaultInstanceMappings)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix, version bump

* **What is the current behavior?** (You can also link to an open issue here)
client tests (TestClient) are broken on cloud due to wrong MARQO_CLOUD_URL being set
py-marqo version is 3.10.0

* **What is the new behavior (if this is a feature change)?**
delete MARQO_CLOUD_URL env var in tests, save and reload it in setUp and tearDown instead.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:

