### PR TITLE
Support for context documents in search (Personalization) - Revised

### DIFF
--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -224,6 +224,7 @@ class Index:
                text_query_prefix: Optional[str] = None, hybrid_parameters: Optional[dict] = None,
                rerank_depth: Optional[int] = None, facets: Optional[dict] = None,
                track_total_hits: Optional[bool] = None,
+               interpolation_method: Optional[str] = None,
                ) -> Dict[str, Any]:
         """Search the index.
 
@@ -264,6 +265,9 @@ class Index:
             rerank_depth: The number of documents to rerank with score modifiers if used with hybrid search.
                 Number of hits to get from each shard if used with tensor search.
             facets: a dictionary of facets to be used for facet search.
+            track_total_hits: whether to track total hits or not
+            interpolation_method: the interpolation method to use for combining query & context embeddings.
+
         Returns:
             Dictionary with hits and other metadata
         """
@@ -300,7 +304,8 @@ class Index:
             "textQueryPrefix": text_query_prefix,
             "hybridParameters": hybrid_parameters,
             "facets": facets,
-            "trackTotalHits": track_total_hits
+            "trackTotalHits": track_total_hits,
+            "interpolationMethod": interpolation_method
         }
 
         body = {k: v for k, v in body.items() if v is not None}

--- a/tests/v2_tests/test_search_with_context.py
+++ b/tests/v2_tests/test_search_with_context.py
@@ -6,7 +6,7 @@ from pytest import mark
 
 
 @mark.fixed
-class TestCustomVectorSearch(MarqoTestCase):
+class TestSearchWithContext(MarqoTestCase):
 
     def setUp(self) -> None:
         super().setUp()
@@ -31,6 +31,11 @@ class TestCustomVectorSearch(MarqoTestCase):
                         "Title": "The history of dogs",
                         "Description": "A history of household pets",
                         "_id": "d2"
+                    },
+                    {
+                        "Title": "Another history of dogs",
+                        "Description": "Second history of household pets",
+                        "_id": "d3"
                     }
                 ], tensor_fields=["Title", "Description"]
             )
@@ -38,10 +43,10 @@ class TestCustomVectorSearch(MarqoTestCase):
 
         self.query = {"What are the best pets": 1}
 
-    def search_with_context(self, context_vector: Optional[Dict[str, List[Dict[str, Any]]]] = None) -> Dict[str, Any]:
+    def search_with_context(self, context_object: Optional[Dict[str, List[Dict[str, Any]]]] = None) -> Dict[str, Any]:
         return self.client.index(self.test_index_name).search(
             q=self.query,
-            context=context_vector
+            context=context_object
         )
 
     def test_custom_vector_search_format(self):
@@ -135,3 +140,143 @@ class TestCustomVectorSearch(MarqoTestCase):
 
             ## Ensure other tests are not affected
             self.query = {"What are the best pets": 1}
+
+    def test_context_documents_alone_full_parameters_succeeds(self):
+        """
+        Test that the context documents alone are sufficient to return results
+        """
+        context = {
+            "documents": {
+                "ids": {
+                    "d2": 1
+                },
+                "parameters": {
+                    "tensorFields": ["Title", "Description"],
+                    "excludeInputDocuments": True
+                }
+            }
+        }
+        if self.IS_MULTI_INSTANCE:
+            self.warm_request(lambda: self.search_with_context(context))
+
+        custom_res = self.search_with_context(context)
+
+        # Result should be d3 (about dogs), then d1. d2 should be excluded.
+        self.assertEqual(
+            [h["_id"] for h in custom_res["hits"]],
+            ["d3", "d1"]
+        )
+
+    def test_context_documents_alone_empty_parameters_succeeds(self):
+        """
+        Test that the context documents alone are sufficient to return results
+        """
+        context = {
+            "documents": {
+                "ids": {
+                    "d2": 1
+                },
+                "parameters": {}
+            }
+        }
+        if self.IS_MULTI_INSTANCE:
+            self.warm_request(lambda: self.search_with_context(context))
+
+        custom_res = self.search_with_context(context)
+
+        # Result should be d3 (about dogs), then d1. d2 should be excluded.
+        self.assertEqual(
+            [h["_id"] for h in custom_res["hits"]],
+            ["d3", "d1"]
+        )
+
+    def test_context_documents_alone_no_parameters_succeeds(self):
+        context = {
+            "documents": {
+                "ids": {
+                    "d2": 1
+                }
+            }
+        }
+        if self.IS_MULTI_INSTANCE:
+            self.warm_request(lambda: self.search_with_context(context))
+
+        custom_res = self.search_with_context(context)
+
+        # Result should be d3 (about dogs), then d1. d2 should be excluded.
+        self.assertEqual(
+            [h["_id"] for h in custom_res["hits"]],
+            ["d3", "d1"]
+        )
+
+    def test_context_documents_alone_no_ids_fails(self):
+        """
+        Test that the context documents alone without any ids fails
+        """
+        context = {
+            "documents": {
+                "parameters": {
+                    "tensorFields": ["Title", "Description"],
+                    "excludeInputDocuments": True
+                }
+            }
+        }
+        if self.IS_MULTI_INSTANCE:
+            self.warm_request(lambda: self.search_with_context(context))
+
+        with self.assertRaises(MarqoWebError) as e:
+            self.search_with_context(context)
+        self.assertIn("must be present and a non-empty list", str(e.exception))
+
+    def test_context_documents_tensors_and_queries_succeeds(self):
+        """
+        Test that the context documents with tensors and queries are sufficient to return results
+        Use all 3 interpolation methods (LERP, NLERP, SLERP)
+        Use context.documents.parameters.excludeInputDocuments (True and False)
+        Use context.documents.parameters.tensorFields (with or without)
+        """
+        interpolation_types = ["LERP", "NLERP", "SLERP"]
+        exclude_input_documents = [True, False]
+        tensor_fields = [["Title", "Description"], None]
+
+        for interpolation_type in interpolation_types:
+            for exclude_input_document in exclude_input_documents:
+                for tensor_field in tensor_fields:
+                    with self.subTest(interpolation_type=interpolation_type,
+                                      exclude_input_document=exclude_input_document,
+                                      tensor_field=tensor_field):
+
+                        context = {
+                            "tensor": [
+                                {"vector": [1, ] * self.vector_dim, "weight": 0},
+                                {"vector": [2, ] * self.vector_dim, "weight": 1}
+                            ],
+                            "documents": {
+                                "ids": {
+                                    "d2": 1
+                                },
+                                "parameters": {
+                                    "excludeInputDocuments": exclude_input_document,
+                                    "tensorFields": tensor_field
+                                }
+                            }
+                        }
+                        if self.IS_MULTI_INSTANCE:
+                            self.warm_request(lambda: self.search_with_context(context))
+
+                        custom_res = self.search_with_context(context)
+
+                        # Result should be d3 (about dogs), then d1. d2 should be excluded.
+                        if exclude_input_document:
+                            self.assertEqual(
+                                set(["d3", "d1"]),
+                                set([h["_id"] for h in custom_res["hits"]])
+                            )
+                        else:
+                            # If excludeInputDocuments is False, d2 should be included
+                            self.assertEqual(
+                                set(["d2", "d3", "d1"]),
+                                set([h["_id"] for h in custom_res["hits"]])
+                            )
+
+

--- a/tests/v2_tests/test_search_with_context.py
+++ b/tests/v2_tests/test_search_with_context.py
@@ -226,7 +226,7 @@ class TestSearchWithContext(MarqoTestCase):
 
         with self.assertRaises(MarqoWebError) as e:
             self.search_with_context(context)
-        self.assertIn("must be present and a non-empty list", str(e.exception))
+        self.assertIn("must be present and a non-empty dict", str(e.exception))
 
     def test_context_documents_tensors_and_queries_succeeds(self):
         """

--- a/tests/v2_tests/test_search_with_context.py
+++ b/tests/v2_tests/test_search_with_context.py
@@ -43,10 +43,12 @@ class TestSearchWithContext(MarqoTestCase):
 
         self.query = {"What are the best pets": 1}
 
-    def search_with_context(self, context_object: Optional[Dict[str, List[Dict[str, Any]]]] = None) -> Dict[str, Any]:
+    def search_with_context(self, context_object: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+                            interpolation_method: str = None) -> Dict[str, Any]:
         return self.client.index(self.test_index_name).search(
             q=self.query,
-            context=context_object
+            context=context_object,
+            interpolation_method=interpolation_method
         )
 
     def test_custom_vector_search_format(self):
@@ -262,9 +264,10 @@ class TestSearchWithContext(MarqoTestCase):
                             }
                         }
                         if self.IS_MULTI_INSTANCE:
-                            self.warm_request(lambda: self.search_with_context(context))
+                            self.warm_request(lambda: self.search_with_context(context,
+                                                                               interpolation_method=interpolation_type))
 
-                        custom_res = self.search_with_context(context)
+                        custom_res = self.search_with_context(context, interpolation_method=interpolation_type)
 
                         # Result should be d3 (about dogs), then d1. d2 should be excluded.
                         if exclude_input_document:

--- a/unit_tests/test_index_search_endpoint.py
+++ b/unit_tests/test_index_search_endpoint.py
@@ -130,3 +130,52 @@ class TestIndexSearchEndpointRelevanceCutoff(MarqoUnitTests):
         self.assertEqual(1, mock_send_request.call_count)
         body = mock_send_request.call_args[0][2]
         self.assertNotIn("relevanceCutoff", body)
+
+class TestIndexSearchEndpointInterpolationMethod(MarqoUnitTests):
+    """
+    Test class for the Index search endpoint interpolation_method parameter.
+    """
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up the class by creating a test index.
+        """
+        config = Config(
+            instance_mappings=DefaultInstanceMappings(url="http://unit-tests-url:8882"),
+        )
+        cls.index = Index(config=config, index_name="test_index")
+
+    @patch('marqo._httprequests.HttpRequests.send_request')
+    def test_interpolation_method_parameter(self, mock_send_request):
+        mock_response = MagicMock()
+        mock_send_request.return_value = mock_response
+
+        interpolation_method = "SLERP"
+
+        self.index.search(q= "test", interpolation_method=interpolation_method)
+
+        self.assertEqual(1, mock_send_request.call_count)
+        body = mock_send_request.call_args[0][2]
+        self.assertEqual(interpolation_method, body["interpolationMethod"])
+
+    @patch('marqo._httprequests.HttpRequests.send_request')
+    def test_interpolation_method_parameter_none(self, mock_send_request):
+        mock_response = MagicMock()
+        mock_send_request.return_value = mock_response
+
+        interpolation_method = None
+
+        self.index.search(q= "test", interpolation_method=interpolation_method)
+        body = mock_send_request.call_args[0][2]
+        self.assertNotIn("interpolationMethod", body)
+
+    @patch('marqo._httprequests.HttpRequests.send_request')
+    def test_interpolation_method_parameter_not_exists(self, mock_send_request):
+        mock_response = MagicMock()
+        mock_send_request.return_value = mock_response
+
+        self.index.search(q= "test")
+
+        self.assertEqual(1, mock_send_request.call_count)
+        body = mock_send_request.call_args[0][2]
+        self.assertNotIn("interpolationMethod", body)


### PR DESCRIPTION
Re-opened PR. Duplicate of https://github.com/marqo-ai/py-marqo/pull/287 which got merged but then reverted due to personalization being reverted in Marqo 2.21.0 (client bug)

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
No support for interpolation method

* **What is the new behavior (if this is a feature change)?**
Added new parameter to search: `interpolation_method`
Added tests for context documents

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

