### PR TITLE
Fix eject model tests

### DIFF
--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -919,7 +919,7 @@ class Index:
 
     def eject_model(self, model_name: str, model_device: str):
         return self.http.delete(
-            path=f"models?model_name={model_name}&model_device={model_device}", index_name=self.index_name
+            path=f"models?model_name={model_name}", index_name=self.index_name
         )
 
     def _marqo_minimum_supported_version_check(self):

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -917,7 +917,7 @@ class Index:
     def get_marqo(self):
         return self.http.get(path="", index_name=self.index_name)
 
-    def eject_model(self, model_name: str, model_device: str):
+    def eject_model(self, model_name: str):
         return self.http.delete(
             path=f"models?model_name={model_name}", index_name=self.index_name
         )

--- a/tests/v2_tests/test_model_cache_management.py
+++ b/tests/v2_tests/test_model_cache_management.py
@@ -98,7 +98,7 @@ class TestModelCacheManagement(MarqoTestCase):
         }
         self.client.index(test_index_name).add_documents([d1], device="cpu", tensor_fields=["doc_title", "field_1"])
         res = self.client.index(test_index_name).eject_model(
-            self.MODEL if not self.client.config.is_marqo_cloud else MODEL, "cpu"
+            self.MODEL if not self.client.config.is_marqo_cloud else MODEL
         )
 
         self.assertEqual("success", res["result"])

--- a/tests/v2_tests/test_model_cache_management.py
+++ b/tests/v2_tests/test_model_cache_management.py
@@ -49,8 +49,8 @@ class TestModelCacheManagement(MarqoTestCase):
             )
             res = self.client.index(test_index_name).get_loaded_models()
 
-            if "models" not in res:
-                raise AssertionError
+            self.assertIn("models", res)
+            self.assertGreaterEqual(len(res["models"]), 1)
 
     def test_eject_all_models(self) -> None:
         for cloud_test_index_to_use, open_source_test_index_name in self.test_cases:
@@ -60,21 +60,19 @@ class TestModelCacheManagement(MarqoTestCase):
             )
             res = self.client.index(test_index_name).get_loaded_models()
             for model in res["models"]:
-                self.client.index(test_index_name).eject_model(model["model_name"], model["model_device"])
+                self.client.index(test_index_name).eject_model(model["modelName"])
             res = self.client.index(test_index_name).get_loaded_models()
-            assert len(res["models"]) == 0
-            assert res["models"] == []
+            self.assertEqual(0, len(res["models"]))
 
     def test_eject_no_cached_model(self) -> None:
         # test a model that is not cached
         try:
-            settings = {"model": self.MODEL}
             for cloud_test_index_to_use, open_source_test_index_name in self.test_cases:
                 test_index_name = self.get_test_index_name(
                     cloud_test_index_to_use=cloud_test_index_to_use,
                     open_source_test_index_name=open_source_test_index_name
                 )
-                res = self.client.index(test_index_name).eject_model("void_model", "void_device")
+                res = self.client.index(test_index_name).eject_model("void_model")
                 raise AssertionError
         except MarqoWebError:
             pass
@@ -102,8 +100,9 @@ class TestModelCacheManagement(MarqoTestCase):
         res = self.client.index(test_index_name).eject_model(
             self.MODEL if not self.client.config.is_marqo_cloud else MODEL, "cpu"
         )
-        assert res["result"] == "success"
-        assert res["message"].startswith("successfully eject")
+
+        self.assertEqual("success", res["result"])
+        self.assertIn("successfully ejected model", res["message"].lower())
 
         if not self.client.config.is_marqo_cloud:
             self.client.delete_index(test_index_name)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix the eject model endpoint/tests due the the removal of the concept `device` in Triton.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes a public client method signature and request shape for model ejection, which can break downstream callers relying on the old `model_device` parameter.
> 
> **Overview**
> Updates the client `Index.eject_model()` to no longer accept/emit `model_device`, calling the `DELETE models` endpoint with only `model_name`.
> 
> Fixes the model-cache management tests to match the new API/response shape (e.g., using `model["modelName"]`), and tightens assertions around loaded-models presence and eject success messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6896ef14365c8eb100d620f2166b2777abaca852. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->