### PR TITLE
feat: add rerank_depth_start parameter to search()

### DIFF
--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -226,7 +226,9 @@ class Index:
                model_auth: Optional[dict] = None,
                ef_search: Optional[int] = None, approximate: Optional[bool] = None,
                text_query_prefix: Optional[str] = None, hybrid_parameters: Optional[dict] = None,
-               rerank_depth: Optional[int] = None, facets: Optional[dict] = None,
+               rerank_depth: Optional[int] = None,
+               rerank_depth_start: Optional[int] = None,
+               facets: Optional[dict] = None,
                track_total_hits: Optional[bool] = None,
                approximate_threshold: Optional[float] = None,
                language: Optional[str] = None,
@@ -273,6 +275,11 @@ class Index:
             hybrid_parameters: a dictionary of parameters to be used for hybrid search
             rerank_depth: The number of documents to rerank with score modifiers if used with hybrid search.
                 Number of hits to get from each shard if used with tensor search.
+            rerank_depth_start: The index of the first result to rerank. Hits before this position
+                are preserved as-is (their scores and order are unchanged). Only hits in
+                [rerank_depth_start, rerank_depth) are subject to global score modifiers and
+                reranking. Must be a non-negative integer less than rerank_depth if both are set.
+                Default is 0 (rerank all hits within rerank_depth).
             facets: a dictionary of facets to be used for facet search.
             track_total_hits: Set to True to return total number of lexical or tensor matches
             approximate_threshold: hit ratio threshold for deciding if a nearest neighbor search should be performed as
@@ -312,6 +319,7 @@ class Index:
             "limit": limit,
             "offset": offset,
             "rerankDepth": rerank_depth,
+            "rerankDepthStart": rerank_depth_start,
             "searchMethod": search_method,
             "showHighlights": show_highlights,
             "reRanker": reranker,

--- a/tests/v2_tests/test_score_modifier_search.py
+++ b/tests/v2_tests/test_score_modifier_search.py
@@ -1,4 +1,6 @@
+import copy
 from typing import Any, Dict, List, Optional
+from unittest import mock
 
 from marqo.errors import MarqoWebError
 from tests.marqo_test import MarqoTestCase, CloudTestIndex
@@ -214,3 +216,72 @@ class TestScoreModifierWithRerankCountSearch(MarqoTestCase):
         self.assertAlmostEqual(modified_results["hits"][0]["_score"], unmodified_scores["tensor1"])  # unmodified
         self.assertAlmostEqual(modified_results["hits"][1]["_score"], unmodified_scores["tensor2"])  # unmodified
         self.assertAlmostEqual(modified_results["hits"][2]["_score"], -1 * unmodified_scores["both1"] - 1)  # modified
+
+
+@mark.fixed
+class TestRerankDepthStartSerialization(MarqoTestCase):
+    """Unit tests verifying rerank_depth_start serialization in the py-marqo client."""
+
+    def test_rerank_depth_start_serialized_as_camel_case(self):
+        """rerank_depth_start must appear as rerankDepthStart in the request body."""
+        temp_client = copy.deepcopy(self.client)
+        mock__post = mock.MagicMock()
+
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            temp_client.index("any_index").search(
+                q="test query",
+                search_method="HYBRID",
+                rerank_depth=50,
+                rerank_depth_start=5,
+            )
+            return True
+
+        run()
+        _, kwargs = mock__post.call_args_list[0]
+        body = kwargs["body"]
+        self.assertIn("rerankDepthStart", body)
+        self.assertEqual(body["rerankDepthStart"], 5)
+        self.assertIn("rerankDepth", body)
+        self.assertEqual(body["rerankDepth"], 50)
+
+    def test_rerank_depth_start_none_omitted_from_body(self):
+        """When rerank_depth_start is None, it must not appear in the request body."""
+        temp_client = copy.deepcopy(self.client)
+        mock__post = mock.MagicMock()
+
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            temp_client.index("any_index").search(
+                q="test query",
+                search_method="HYBRID",
+                rerank_depth=50,
+                rerank_depth_start=None,
+            )
+            return True
+
+        run()
+        _, kwargs = mock__post.call_args_list[0]
+        body = kwargs["body"]
+        self.assertNotIn("rerankDepthStart", body)
+
+    def test_rerank_depth_start_zero_included_in_body(self):
+        """rerank_depth_start=0 must appear in the request body (0 is falsy but valid)."""
+        temp_client = copy.deepcopy(self.client)
+        mock__post = mock.MagicMock()
+
+        @mock.patch("marqo._httprequests.HttpRequests.post", mock__post)
+        def run():
+            temp_client.index("any_index").search(
+                q="test query",
+                search_method="HYBRID",
+                rerank_depth=50,
+                rerank_depth_start=0,
+            )
+            return True
+
+        run()
+        _, kwargs = mock__post.call_args_list[0]
+        body = kwargs["body"]
+        self.assertIn("rerankDepthStart", body)
+        self.assertEqual(body["rerankDepthStart"], 0)


### PR DESCRIPTION
## Summary
- Adds `rerank_depth_start: Optional[int] = None` parameter to `Index.search()`
- Serialises as `rerankDepthStart` in the Marqo API request body
- Follows the same pattern as `rerank_depth` / `rerankDepth`
- `None` value is omitted from the request body (existing behaviour preserved)

**Server-side PR:** marqo-ai/marqo#1393

## Test plan
- [x] `test_rerank_depth_start_serialized_as_camel_case` — verifies correct key name in request body
- [x] `test_rerank_depth_start_none_omitted_from_body` — verifies `None` is not sent
- [x] `test_rerank_depth_start_zero_included_in_body` — verifies `0` (falsy but valid) is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional search parameter that is omitted when `None`, with unit tests covering serialization and the `0` edge case.
> 
> **Overview**
> Adds a new optional `rerank_depth_start` parameter to `Index.search()` and serializes it to the API as `rerankDepthStart`, enabling reranking/score modifiers to apply only to a specified slice of the top `rerank_depth` results.
> 
> Includes unit tests that mock the HTTP layer to verify camelCase serialization, omission when `None`, and inclusion when set to `0` (falsy but valid).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07f2288324c958906d7a9ba73c3e3ea9f5817dde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->