### PR TITLE
Deprecate inference_type and number_of_inferences

### DIFF
--- a/src/marqo/client.py
+++ b/src/marqo/client.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import warnings
 from typing import Any, Dict, List, Optional
 
 from pydantic import error_wrappers
@@ -133,13 +134,11 @@ class Client:
             wait_for_readiness: Marqo Cloud specific, whether to wait until
                 operation is completed or to proceed without waiting for status,
                 won't do anything if config.is_marqo_cloud=False
-            inference_type: inference type for the index
             storage_class: storage class for the index
-            number_of_inferences: number of inferences for the index
             number_of_shards: number of shards for the index
             number_of_replicas: number of replicas for the index
         Note:
-            wait_for_readiness, inference_type, storage_class, number_of_inferences,
+            wait_for_readiness, storage_class,
             number_of_shards, number_of_replicas are Marqo Cloud specific parameters,
 
 
@@ -147,6 +146,20 @@ class Client:
         Returns:
             Response body, containing information about index creation result
         """
+        if inference_type is not None:
+            warnings.warn(
+                "inference_type is deprecated and will be removed in a future version. "
+                "This parameter is no longer used and will be ignored.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if number_of_inferences is not None:
+            warnings.warn(
+                "number_of_inferences is deprecated and will be removed in a future version. "
+                "This parameter is no longer used and will be ignored.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return Index.create(
             config=self.config, index_name=index_name,
             type=type, settings_dict=settings_dict,
@@ -163,11 +176,9 @@ class Client:
             vector_numeric_type=vector_numeric_type,
             ann_parameters=ann_parameters,
             wait_for_readiness=wait_for_readiness,
-            inference_type=inference_type,
             storage_class=storage_class,
             number_of_shards=number_of_shards,
             number_of_replicas=number_of_replicas,
-            number_of_inferences=number_of_inferences,
             text_query_prefix=text_query_prefix,
             text_chunk_prefix=text_chunk_prefix,
         )

--- a/src/marqo/index.py
+++ b/src/marqo/index.py
@@ -1,4 +1,5 @@
 import functools
+import warnings
 from datetime import datetime
 from timeit import default_timer as timer
 from typing import Any, Dict, List, Optional, Union
@@ -133,18 +134,30 @@ class Index:
             wait_for_readiness: Marqo Cloud specific, whether to wait until
                 operation is completed or to proceed without waiting for status,
                 won't do anything if config.is_marqo_cloud=False
-            inference_type: inference type for the index
             storage_class: storage class for the index
-            number_of_inferences: number of inferences for the index
             number_of_shards: number of shards for the index
             number_of_replicas: number of replicas for the index
             collapse_fields: list of fields that can be collapsed on at query time
         Note:
-            wait_for_readiness, inference_type, storage_class, number_of_inferences,
+            wait_for_readiness, storage_class,
             number_of_shards, number_of_replicas are Marqo Cloud specific parameters,
         Returns:
             Response body, containing information about index creation result
         """
+        if inference_type is not None:
+            warnings.warn(
+                "inference_type is deprecated and will be removed in a future version. "
+                "This parameter is no longer used and will be ignored.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if number_of_inferences is not None:
+            warnings.warn(
+                "number_of_inferences is deprecated and will be removed in a future version. "
+                "This parameter is no longer used and will be ignored.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         req = HttpRequests(config)
 
         # py-marqo against local Marqo
@@ -191,8 +204,6 @@ class Index:
                 videoPreprocessing=video_preprocessing,
                 vectorNumericType=vector_numeric_type,
                 annParameters=ann_parameters,
-                numberOfInferences=number_of_inferences,
-                inferenceType=inference_type,
                 numberOfShards=number_of_shards,
                 numberOfReplicas=number_of_replicas,
                 storageClass=storage_class,

--- a/src/marqo/models/marqo_cloud.py
+++ b/src/marqo/models/marqo_cloud.py
@@ -9,11 +9,9 @@ from marqo.enums import IndexStatus
 
 
 class CloudIndexSettings(IndexSettings):
-    inferenceType: Optional[str] = Field(None, alias="inference_type")
     storageClass: Optional[str] = Field(None, alias="storage_class")
     numberOfReplicas: Optional[int] = Field(None, alias="number_of_replicas")
     numberOfShards: Optional[int] = Field(None, alias="number_of_shards")
-    numberOfInferences: Optional[int] = Field(None, alias="number_of_inferences")
 
 
 class ListIndexesResponse(CloudIndexSettings):

--- a/tests/cloud_test_logic/cloud_test_index.py
+++ b/tests/cloud_test_logic/cloud_test_index.py
@@ -39,8 +39,6 @@ index_name_to_settings_mappings = {
         "type": "unstructured",
         "treatUrlsAndPointersAsImages": False,
         "model": "hf/e5-base-v2",
-
-        "inferenceType": "marqo.CPU.small",
         "storageClass": "marqo.balanced",
         "numberOfShards": 2,
         "numberOfReplicas": 1,  # For hybrid duplicates test
@@ -49,8 +47,6 @@ index_name_to_settings_mappings = {
         "type": "unstructured",
         "treatUrlsAndPointersAsImages": True,
         "model": "open_clip/ViT-B-32/laion2b_s34b_b79k",
-
-        "inferenceType": "marqo.CPU.small",
         "storageClass": "marqo.basic",
         "numberOfShards": 1,
         "numberOfReplicas": 0,
@@ -70,7 +66,6 @@ index_name_to_settings_mappings = {
             {"name": "map_long_score_modifier_field", "type": "map<text, long>", "features": ["score_modifier"]},
         ],
         "tensorFields": ["text_field_1", "text_field_2", "text_field_3"],
-        "inferenceType": "marqo.CPU.small",
         "storageClass": "marqo.balanced",
         "numberOfShards": 2,
         "numberOfReplicas": 1, # For hybrid duplicates test
@@ -78,8 +73,6 @@ index_name_to_settings_mappings = {
     CloudTestIndex.structured_image: {
         "type": "structured",
         "model": "open_clip/ViT-B-32/laion2b_s34b_b79k",
-
-        "inferenceType": "marqo.CPU.small",
         "storageClass": "marqo.balanced",
         "numberOfShards": 2,
         "numberOfReplicas": 1,  # For hybrid duplicates test

--- a/tests/v2_tests/test_create_index.py
+++ b/tests/v2_tests/test_create_index.py
@@ -385,11 +385,9 @@ class TestCreateIndex(MarqoTestCase):
         """Test that settings_dict cannot be specified with other index creation
         parameters in cloud create_index call."""
         parameters_pool = {
-            "inference_type": "marqo.CPU.large",
             "storage_class": "marqo.basic",
             "number_of_replicas": 1,
             "number_of_shards": 1,
-            "number_of_inferences": 1
         }
 
         test_cloud_client = Client("https://api.marqo.ai", api_key="test")
@@ -421,10 +419,8 @@ class TestCreateIndex(MarqoTestCase):
 class TestCloudCreateIndex(MarqoTestCase):
 
     TEST_ATTRIBUTES_WITH_DEFAULTS = {
-        "inferenceType": "CPU.SMALL",
         "numberOfShards": 1,
         "numberOfReplicas": 0,
-        "numberOfInferences": 1,
         "storageClass": "BASIC"
     }
 

--- a/tests/v2_tests/test_index.py
+++ b/tests/v2_tests/test_index.py
@@ -224,35 +224,14 @@ class TestIndex(MarqoTestCase):
                 client.config.is_marqo_cloud = True
 
                 result = client.create_index(
-                    index_name=self.generic_test_index_name, inference_type="marqo.CPU.large", number_of_inferences=1,
+                    index_name=self.generic_test_index_name,
                     storage_class="marqo.basic"
                 )
 
                 mock_post.assert_called_with(f'indexes/{self.generic_test_index_name}', body={
-                    'inferenceType': "marqo.CPU.large", 'storageClass': "marqo.basic", 'numberOfInferences': 1})
+                    'storageClass': "marqo.basic"})
                 mock_get.assert_called_with(f"indexes/{self.generic_test_index_name}/status")
                 assert result == {"acknowledged": True}
-
-    @mark.fixed
-    @mock.patch("marqo._httprequests.HttpRequests.post", return_value={"error": "inferenceType is required"})
-    @mock.patch("marqo._httprequests.HttpRequests.get", return_value={"indexStatus": "READY"})
-    def test_create_marqo_cloud_index_wrong_inference_settings(self, mock_get, mock_post):
-        client = copy.deepcopy(self.client)
-        for cloud_api_endpoint in constants.CLOUD_API_ENDPOINTS:
-            with self.subTest(cloud_api_endpoint=cloud_api_endpoint):
-                client.config.instance_mapping = MarqoCloudInstanceMappings(cloud_api_endpoint)
-                client.config.api_key = 'some-super-secret-API-key'
-                client.config.is_marqo_cloud = True
-
-                result = client.create_index(
-                    index_name=self.generic_test_index_name, inference_type=None, number_of_inferences=1,
-                    storage_class="marqo.basic"
-                )
-
-                mock_post.assert_called_with(f'indexes/{self.generic_test_index_name}', body={
-                    "storageClass": "marqo.basic", "numberOfInferences": 1})
-                mock_get.assert_called_with(f"indexes/{self.generic_test_index_name}/status")
-                assert result == {"error": "inferenceType is required"}
 
     @mark.fixed
     @mock.patch("marqo._httprequests.HttpRequests.post", return_value={"error": "storageClass is required"})
@@ -266,12 +245,11 @@ class TestIndex(MarqoTestCase):
                 client.config.is_marqo_cloud = True
 
                 result = client.create_index(
-                    index_name=self.generic_test_index_name, inference_type="CPU.small", number_of_inferences=1,
+                    index_name=self.generic_test_index_name,
                     storage_class=None
                 )
 
-                mock_post.assert_called_with(f'indexes/{self.generic_test_index_name}', body={
-                    "inferenceType": "CPU.small", "numberOfInferences": 1})
+                mock_post.assert_called_with(f'indexes/{self.generic_test_index_name}', body={})
                 mock_get.assert_called_with(f"indexes/{self.generic_test_index_name}/status")
                 assert result == {"error": "storageClass is required"}
 

--- a/tests/v2_tests/test_index.py
+++ b/tests/v2_tests/test_index.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 
 from pytest import mark
 
@@ -252,6 +253,97 @@ class TestIndex(MarqoTestCase):
                 mock_post.assert_called_with(f'indexes/{self.generic_test_index_name}', body={})
                 mock_get.assert_called_with(f"indexes/{self.generic_test_index_name}/status")
                 assert result == {"error": "storageClass is required"}
+
+    @mark.fixed
+    @mock.patch("marqo._httprequests.HttpRequests.post", return_value={"acknowledged": True})
+    @mock.patch("marqo._httprequests.HttpRequests.get", return_value={"indexStatus": "READY"})
+    def test_create_index_inference_type_emits_deprecation_warning(self, mock_get, mock_post):
+        """Test that passing inference_type emits a DeprecationWarning and the parameter is ignored."""
+        client = copy.deepcopy(self.client)
+        client.config.instance_mapping = MarqoCloudInstanceMappings(constants.CLOUD_API_ENDPOINTS[0])
+        client.config.api_key = 'some-super-secret-API-key'
+        client.config.is_marqo_cloud = True
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.create_index(
+                index_name=self.generic_test_index_name,
+                inference_type="marqo.CPU.large",
+                storage_class="marqo.basic"
+            )
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertEqual(len(deprecation_warnings), 1)
+            self.assertIn("inference_type is deprecated", str(deprecation_warnings[0].message))
+
+        mock_post.assert_called_with(f'indexes/{self.generic_test_index_name}', body={
+            'storageClass': "marqo.basic"})
+
+    @mark.fixed
+    @mock.patch("marqo._httprequests.HttpRequests.post", return_value={"acknowledged": True})
+    @mock.patch("marqo._httprequests.HttpRequests.get", return_value={"indexStatus": "READY"})
+    def test_create_index_number_of_inferences_emits_deprecation_warning(self, mock_get, mock_post):
+        """Test that passing number_of_inferences emits a DeprecationWarning and the parameter is ignored."""
+        client = copy.deepcopy(self.client)
+        client.config.instance_mapping = MarqoCloudInstanceMappings(constants.CLOUD_API_ENDPOINTS[0])
+        client.config.api_key = 'some-super-secret-API-key'
+        client.config.is_marqo_cloud = True
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.create_index(
+                index_name=self.generic_test_index_name,
+                number_of_inferences=2,
+                storage_class="marqo.basic"
+            )
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertEqual(len(deprecation_warnings), 1)
+            self.assertIn("number_of_inferences is deprecated", str(deprecation_warnings[0].message))
+
+        mock_post.assert_called_with(f'indexes/{self.generic_test_index_name}', body={
+            'storageClass': "marqo.basic"})
+
+    @mark.fixed
+    @mock.patch("marqo._httprequests.HttpRequests.post", return_value={"acknowledged": True})
+    @mock.patch("marqo._httprequests.HttpRequests.get", return_value={"indexStatus": "READY"})
+    def test_create_index_both_deprecated_params_emit_warnings(self, mock_get, mock_post):
+        """Test that passing both deprecated params emits two DeprecationWarnings."""
+        client = copy.deepcopy(self.client)
+        client.config.instance_mapping = MarqoCloudInstanceMappings(constants.CLOUD_API_ENDPOINTS[0])
+        client.config.api_key = 'some-super-secret-API-key'
+        client.config.is_marqo_cloud = True
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.create_index(
+                index_name=self.generic_test_index_name,
+                inference_type="marqo.CPU.large",
+                number_of_inferences=2,
+                storage_class="marqo.basic"
+            )
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertEqual(len(deprecation_warnings), 2)
+
+        mock_post.assert_called_with(f'indexes/{self.generic_test_index_name}', body={
+            'storageClass': "marqo.basic"})
+
+    @mark.fixed
+    @mock.patch("marqo._httprequests.HttpRequests.post", return_value={"acknowledged": True})
+    @mock.patch("marqo._httprequests.HttpRequests.get", return_value={"indexStatus": "READY"})
+    def test_create_index_no_deprecated_params_no_warning(self, mock_get, mock_post):
+        """Test that not passing deprecated params emits no DeprecationWarning."""
+        client = copy.deepcopy(self.client)
+        client.config.instance_mapping = MarqoCloudInstanceMappings(constants.CLOUD_API_ENDPOINTS[0])
+        client.config.api_key = 'some-super-secret-API-key'
+        client.config.is_marqo_cloud = True
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.create_index(
+                index_name=self.generic_test_index_name,
+                storage_class="marqo.basic"
+            )
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertEqual(len(deprecation_warnings), 0)
 
     @mark.fixed
     def test_version_check_multiple_instantiation(self):


### PR DESCRIPTION
## Summary
- `inference_type` and `number_of_inferences` params still accepted for backward compatibility but emit `DeprecationWarning` and are no longer sent to the API
- Removed `inferenceType` and `numberOfInferences` from `CloudIndexSettings` model
- Updated cloud integration test settings and assertions to not reference deprecated fields
- Removed obsolete `test_create_marqo_cloud_index_wrong_inference_settings` test

## Test plan
- [ ] Unit tests pass for deprecation warning behavior
- [ ] Cloud integration tests pass without `inferenceType` / `numberOfInferences` assertions
- [ ] Existing callers passing `inference_type` or `number_of_inferences` see deprecation warning but no breakage