### PR TITLE
test: loosen embed-equality tolerance for unstructured indexes

### DIFF
--- a/tests/v2_tests/test_embed.py
+++ b/tests/v2_tests/test_embed.py
@@ -45,7 +45,7 @@ class TestEmbed(MarqoTestCase):
                 self.assertIn("processingTimeMs", embed_res_1)
                 self.assertEqual(embed_res_1["content"], "Jimmy Butler is the GOAT.")
                 self.assertTrue(np.allclose(embed_res_1["embeddings"][0], retrieved_d1["_tensor_facets"][0]["_embedding"],
-                                            atol=1e-4))
+                                            atol=1e-3))
 
     def test_request_level_prefix_override_embed_add_docs(self):
         """Checks that the request level prefix override works."""
@@ -75,7 +75,7 @@ class TestEmbed(MarqoTestCase):
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], "test query: Jimmy Butler is the GOAT.")
                 self.assertTrue(np.allclose(embed_res["embeddings"][0], retrieved_d1["_tensor_facets"][0]["_embedding"],
-                                            atol=1e-4))
+                                            atol=1e-3))
 
 
     def test_embed_with_device(self):
@@ -105,7 +105,7 @@ class TestEmbed(MarqoTestCase):
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], "Jimmy Butler is the GOAT.")
                 self.assertTrue(np.allclose(embed_res["embeddings"][0], retrieved_d1["_tensor_facets"][0] ["_embedding"],
-                                            atol=1e-4))
+                                            atol=1e-3))
 
     def test_embed_single_dict(self):
         """Embeds a dict. Use add docs and get docs with tensor facets to ensure the vector is correct.
@@ -135,7 +135,7 @@ class TestEmbed(MarqoTestCase):
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], {"Jimmy Butler is the GOAT.": 1})
                 self.assertTrue(np.allclose(embed_res["embeddings"][0], retrieved_d1["_tensor_facets"][0]["_embedding"],
-                                            atol=1e-4))
+                                            atol=1e-3))
 
 
     def test_embed_list_content(self):
@@ -171,9 +171,9 @@ class TestEmbed(MarqoTestCase):
                 self.assertIn("processingTimeMs", embed_res)
                 self.assertEqual(embed_res["content"], [{"Jimmy Butler is the GOAT.": 1}, "Alex Caruso is the GOAT."])
                 self.assertTrue(
-                    np.allclose(embed_res["embeddings"][0], retrieved_docs["results"][0]["_tensor_facets"][0]["_embedding"], atol=1e-4))
+                    np.allclose(embed_res["embeddings"][0], retrieved_docs["results"][0]["_tensor_facets"][0]["_embedding"], atol=1e-3))
                 self.assertTrue(
-                    np.allclose(embed_res["embeddings"][1], retrieved_docs["results"][1]["_tensor_facets"][0]["_embedding"], atol=1e-4))
+                    np.allclose(embed_res["embeddings"][1], retrieved_docs["results"][1]["_tensor_facets"][0]["_embedding"], atol=1e-3))
 
 
     def test_embed_non_numeric_weight_fails(self):


### PR DESCRIPTION
## What

Loosens the embedding-equality tolerance in `test_embed.py` from `atol=1e-4` to `atol=1e-3` (6 assertions).

## Why

Follow-up to #311, which migrated the embed tests to run against an unstructured index. On unstructured (semi-structured) indexes in Marqo 2.29, the stored `_tensor_facets` embedding and a fresh `embed(content_type="document")` are effectively identical but differ by up to ~6e-4 per component (storage precision), which exceeds the old `atol=1e-4` and fails the tests.

Measured on a local Marqo 2.29.0 unstructured `hf/e5-base-v2` index:

| metric | value |
|---|---|
| cosine similarity | 0.99999852 |
| max abs diff (per component) | 5.66e-4 |
| passes `atol=1e-4` | ❌ |
| passes `atol=1e-3` | ✅ |

This is a storage-precision artifact, not a real embedding difference or a prefix bug (a wrong prefix differs by ~5e-2 — ~50× the new threshold — so genuine mismatches are still caught).

## Verification

`pytest tests/v2_tests/test_embed.py` → all pass against a local Marqo 2.29.0 unstructured index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)